### PR TITLE
Typo in MLIR Getting Started guide

### DIFF
--- a/website/content/getting_started/_index.md
+++ b/website/content/getting_started/_index.md
@@ -40,7 +40,7 @@ REM invoked.
 git clone https://github.com/llvm/llvm-project.git
 mkdir llvm-project\build
 cd llvm-project\build
-cmake ..\llvm -G "Visual Studio 15 2017 Win64" -DLLVM_ENABLE_PROJECT=mlir -DLLVM_BUILD_EXAMPLES=ON -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_BUILD_TYPE=Release -Thost=x64 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
+cmake ..\llvm -G "Visual Studio 15 2017 Win64" -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_BUILD_EXAMPLES=ON -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_BUILD_TYPE=Release -Thost=x64 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
 cmake --build . --target check-mlir
 ```
 


### PR DESCRIPTION
Missing "S" from Windows instructions.