### PR TITLE
Mention Doxygen-style comments in style guide

### DIFF
--- a/website/content/getting_started/DeveloperGuide.md
+++ b/website/content/getting_started/DeveloperGuide.md
@@ -16,6 +16,8 @@ We also adhere to the following (which deviate from or are not specified in the
 LLVM style guide):
 
 *   Adopts [camelBack](https://llvm.org/docs/Proposals/VariableNames.html);
+*   Uses Doxygen-style (`///`) comments for top-level and class member
+    definitions, regardless of them being visible as public APIs.
 *   Except for IR units (Region, Block, and Operation), non-nullable output
     arguments are passed by non-const reference in general.
 *   IR constructs are not designed for [const correctness](../../docs/UsageOfConst.md).


### PR DESCRIPTION
We are following this convention implicitly, making it explicit. The reason for using Doxygen-style comments even for non-public APIs is that these APIs often become public at some point, but the comments are not necessarily updated to reflect that. Also, simpler rules (i.e. not thinking whether you are working on a public API or not) are simpler to follow.