### PR TITLE
Include list of docs in section pages.

### DIFF
--- a/website/themes/mlir/layouts/_default/section.html
+++ b/website/themes/mlir/layouts/_default/section.html
@@ -1,0 +1,20 @@
+{{- define "main" -}}
+<h1>{{ .Title }}</h1>
+{{- .Content -}}
+
+{{- if .Pages -}}
+<h2>{{ .Title }} Docs</h2>
+<ul>
+{{- range .Pages -}}
+{{- if .Title -}}
+<li>
+  <a href="{{.Permalink}}">{{.Title}}</a>
+</li>
+{{- end -}}
+{{- end -}}
+</ul>
+{{- end -}}
+
+{{- partial "edit-meta.html" . -}}
+{{- partial "pagination.html" . -}}
+{{- end -}}


### PR DESCRIPTION
Add a default layout for section pages to include the list of pages in
the section at the bottom of the section page.

For example, the 'Dialects' section page is currently empty. With this
change, the 'Dialects' page includes a list of links to all of the
dialects docs (including autogenerated dialect docs), under the heading
'Dialects Docs'.

The list of subpages is added to section pages with and without content
from a provided _index.md, unless there are no subpages in the section.