### PR TITLE
Ensure to import MathJax

### DIFF
--- a/website/themes/mlir/layouts/partials/head.html
+++ b/website/themes/mlir/layouts/partials/head.html
@@ -20,6 +20,15 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery.easing@1.4.1/jquery.easing.min.js"></script>
 <script src="{{"js/bundle.js" | absURL}}"></script>
+<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [['$', '$'] ],
+      displayMath: [ ['$$','$$'], ["\\[","\\]"] ]
+    }
+  });
+</script>
 {{- partial "meta/google-analytics-async.html" . -}}
 {{- partial "meta/tag-manager.html" . -}}
 {{- partial "meta/google-site-verification.html" . -}}


### PR DESCRIPTION
Affine dialect documentation fails to render the math formulas due to missing MathJax. The library needs to be imported with proper configuration for inline format.

See: https://reviews.llvm.org/D94004