### PR TITLE
[mlir] Fix MathJax load failure

### DIFF
--- a/website/themes/mlir/layouts/partials/head.html
+++ b/website/themes/mlir/layouts/partials/head.html
@@ -20,7 +20,7 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery.easing@1.4.1/jquery.easing.min.js"></script>
 <script src="{{"js/bundle.js" | absURL}}"></script>
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
     tex2jax: {


### PR DESCRIPTION
Since a browser does not allow the insecure load from HTTP resources, the MathJax import fails, which causes the invalid math formulas rendering.

```
Mixed Content: The page at 'https://mlir.llvm.org/docs/Quantization/' was loaded over HTTPS, but requested an insecure script 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'. This request has been blocked; the content must be served over HTTPS.
```

In Chrome `89.0.4389.114`, the following error is shown in the developer console. 

<img width="1676" alt="Screen Shot 2021-04-06 at 21 19 27" src="https://user-images.githubusercontent.com/1713047/113710496-be276d00-971e-11eb-90f1-320fefba0887.png">
