### PR TITLE
[mlir][www] remove reference to topical integration test

### DIFF
--- a/website/content/getting_started/TestingGuide.md
+++ b/website/content/getting_started/TestingGuide.md
@@ -200,11 +200,10 @@ cmake --build . --target check-mlir-integration
 ```
 
 The source files of the integration tests are organized within the `mlir` source
-tree by dialect (for example, `test/Integration/Dialect/Vector`) or by feature
-(for example, `test/Integration/Sparse`). Within these directories, a `CPU`
-directory is used for tests that run with the `mlir-cpu-runner` tool (this
-latter leaf structure may eventually disappear, since so far all tests are
-cpu tests).
+tree by dialect (for example, `test/Integration/Dialect/Vector`). Within these
+directories, a `CPU` directory is used for tests that run with the
+`mlir-cpu-runner` tool (this latter leaf structure may eventually disappear,
+since so far all tests are cpu tests).
 
 ### Emulator
 


### PR DESCRIPTION
Topical Sparse is now a proper SparseTensorDialect and thus
this comment is no longer valid.