### PR TITLE
Change processing of included docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
 
     - name: Install MLIR Source docs
       run:  ./copy_docs.sh llvm_src/mlir/docs/ website/content/docs/ &&
+            ./process_included_docs.sh website/content/docs/ &&
             echo "Hack around file/directory name conflict" && rm -Rf website/content/docs/Interfaces &&
             mkdir -p website/content/includes/ &&
             cp -rv llvm_src/mlir/docs/includes/img website/content/includes/

--- a/copy_docs.sh
+++ b/copy_docs.sh
@@ -36,24 +36,3 @@ find $input_path -name "*.md" | while read file ; do
      grep -v "^# $title" $input_path/$file  | sed 's|\[TOC\]|<p/>{{< toc >}}|' ) > $output_path/$file &&
     echo "Processed $file"
 done
-
-# Collect the locations of included files.
-included_files=$(grep -Ern --include \*.md '^\[include \"(.*)\"\]$' ${PWD}/$output_path \
-              | tac \
-              | sed -E 's/(.*)\[include \"(.*)\"\]$/\1\2/g')
-
-# Inline the contents of the included files.
-for val in $included_files; do
-    read -r file line include <<< $(echo $val | sed -E 's/^(.*)\:([0-9]+)\:(.*)$/\1 \2 \3/g')
-
-    # Strip the title from any included files.
-    if [[ $(head -1 $output_path$include) == '---' ]]; then
-        tail -n +6 $output_path$include > "include.tmp" && mv "include.tmp" $output_path$include
-    fi
-    sed -e "$line {r $output_path$include" -e 'd' -e '}' "$file" > "$file.tmp" && mv -- "$file.tmp" "$file"
-done
-
-# Make sure the included files are removed after processing.
-for val in $included_files; do
-    rm "$output_path/$(echo $val | sed -E 's/^.*\:[0-9]+\:(.*)$/\1/g')" || true
-done

--- a/process_included_docs.sh
+++ b/process_included_docs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+
+output_path=$1
+
+# Collect the locations of included files.
+included_files=$(grep -Ern --include \*.md '^\[include \"(.*)\"\]$' ${PWD}/$output_path \
+              | tac \
+              | sed -E 's/(.*)\[include \"(.*)\"\]$/\1\2/g')
+
+# Inline the contents of the included files.
+for val in $included_files; do
+    read -r file line include <<< $(echo $val | sed -E 's/^(.*)\:([0-9]+)\:(.*)$/\1 \2 \3/g')
+
+    # Strip the title from any included files.
+    if [[ $(head -1 $output_path$include) == '---' ]]; then
+        tail -n +6 $output_path$include > "include.tmp" && mv "include.tmp" $output_path$include
+    fi
+    sed -e "$line {r $output_path$include" -e 'd' -e '}' "$file" > "$file.tmp" && mv -- "$file.tmp" "$file"
+done
+
+# Make sure the included files are removed after processing.
+for val in $included_files; do
+    rm "$output_path/$(echo $val | sed -E 's/^.*\:[0-9]+\:(.*)$/\1/g')" || true
+done


### PR DESCRIPTION
This enables to have manually written docs in auto-generated docs.
So far `copy_docs.sh` was used to copy and process included docs. The
latter is now handled by `process_included_docs.sh`.

The workflow so far looked as follows:

First `cops_docs.sh` call:
* Copies all auto-generated docs/files generated during the build
  process to `website/content/docs/`.
* Processes all included files. In consequence these can only be
  auto-generated files since no other files were copied to
  `website/content/docs/` so far.
* Removes all include statements from the markdown files.

Second `cops_docs.sh` call:
* Copies all hand-written docs to `website/content/docs`.
* Processes all included files. These can be auto-generated or
  hand-written files.
* Removes all include statements form the files copied with the second
  `copy_docs.sh` call, as all other include statements were already
  removed.

This is changed to copy auto-generated and manually-written files before
processing any include statement. This allows to have include statements
in both kind of doc files.
