### PR TITLE
Repoint MLIR paper link to the CGO paper

### DIFF
--- a/website/content/talks/_index.md
+++ b/website/content/talks/_index.md
@@ -257,9 +257,13 @@ recording [part 1](https://drive.google.com/a/google.com/file/d/1JvirzO_LgUTacs0
 
 ### About MLIR and MLIR Components
 
-* [MLIR: A Compiler Infrastructure for the End of Moore's Law](https://arxiv.org/abs/2002.11054) -
-   Chris Lattner, Mehdi Amini, Uday Bondhugula, Albert Cohen, Andy Davis, Jacques Pienaar,
-   River Riddle, Tatiana Shpeisman, Nicolas Vasilache, Oleksandr Zinenko
+* [MLIR: Scaling Compiler Infrastructure for Domain Specific
+  Computation](https://ieeexplore.ieee.org/abstract/document/9370308) -
+  Chris Lattner, Mehdi Amini, Uday Bondhugula, Albert Cohen, Andy Davis, Jacques Pienaar, River Riddle, Tatiana Shpeisman, Nicolas Vasilache, Oleksandr Zinenko - In proceedings of 2021 IEEE/ACM International Symposium on Code Generation and Optimization (CGO) -
+  pp. 2-14 -
+  A preprint is available on [arXiv](https://arxiv.org/abs/2002.11054), see
+  [FAQ](https://mlir.llvm.org/getting_started/Faq/#how-to-refer-to-mlir-in-publications-is-there-an-accompanying-paper)
+  for citation how-to.
 
 ### Using MLIR
 


### PR DESCRIPTION
It has been pointing to the arXiv preprint before, which could lead
people to cite the preprint instead of the actual paper. Repoint the
link to the actual paper and reference the FAQ entry for citations.