### PR TITLE
Fix 404 Link Error in Glossary.md

### DIFF
--- a/website/content/getting_started/Glossary.md
+++ b/website/content/getting_started/Glossary.md
@@ -105,7 +105,7 @@ The process of transforming a higher-level representation of an operation into a
 lower-level, but semantically equivalent, representation.
 
 In MLIR, this is typically accomplished through
-[dialect conversion](../docs/DialectConversion). This provides a framework by which
+[dialect conversion](../docs/DialectConversion.md). This provides a framework by which
 to define the requirements of the lower-level representation, called the
 [conversion target](DialectConversion.md#conversion-target), by specifying which
 operations are legal versus illegal after lowering.

--- a/website/content/getting_started/Glossary.md
+++ b/website/content/getting_started/Glossary.md
@@ -105,7 +105,7 @@ The process of transforming a higher-level representation of an operation into a
 lower-level, but semantically equivalent, representation.
 
 In MLIR, this is typically accomplished through
-[dialect conversion](DialectConversion.md). This provides a framework by which
+[dialect conversion](../docs/DialectConversion). This provides a framework by which
 to define the requirements of the lower-level representation, called the
 [conversion target](DialectConversion.md#conversion-target), by specifying which
 operations are legal versus illegal after lowering.


### PR DESCRIPTION
Updated broken link for dialect conversion. It previously linked to https://mlir.llvm.org/getting_started/Glossary/DialectConversion.md which gave a 404 Error. Now it should link to this landing page: https://mlir.llvm.org/docs/DialectConversion/.