### PR TITLE
Change gpu::Serialization* migration message to deprecation

### DIFF
--- a/website/content/deprecation/_index.md
+++ b/website/content/deprecation/_index.md
@@ -68,11 +68,9 @@ If your `mlir-opt`-like tool is using the
 otherwise, see the
 [Discussion on Discourse](https://discourse.llvm.org/t/psa-migrating-mlir-opt-like-tools-to-use-mliroptmainconfig/68991)
 
-### Migrating GPU compilation `gpu-to-(cubin|hsaco)` to GPU compilation attributes
+### Deprecation of `gpu-to-(cubin|hsaco)` in favor of GPU compilation attributes
 
-[Discussion on Discourse](https://discourse.llvm.org/t/rfc-extending-mlir-gpu-device-codegen-pipeline/70199)
-
-GPU compilation attributes are a completely new mechanism for handling the compilation
+[GPU compilation attributes](https://mlir.llvm.org/docs/Dialects/GPU/#gpu-compilation) are a completely new mechanism for handling the compilation
 of GPU modules down to binary or other formats in an extensible way. This mechanism lifts
 many current restrictions the GPU serialization passes had, like being present only if the
 CUDA driver is there or not linking to LibDevice.
@@ -80,7 +78,7 @@ CUDA driver is there or not linking to LibDevice.
 One key difference is the usage of `ptxas` or the `nvptxcompiler` library for compiling PTX
 to binary; hence the CUDATollkit is required for generating binaries.
 
-For these attributes to work correctly, making registration calls to `registerNVVMTarget`,
-`registerROCDLTarget` and `registerGPUDialectTranslation` are necessary.
+For these attributes to work correctly, making registration calls to `registerNVVMTargetInterfaceExternalModels`,
+`registerROCDLTargetInterfaceExternalModels` and `registerOffloadingLLVMTranslationInterfaceExternalModels` are necessary.
 
-The passes `gpu-to-(cubin|hsaco)` will be deprecated and removed in a future release.
+The passes `gpu-to-(cubin|hsaco)` will be removed in a future release.


### PR DESCRIPTION
Change gpu::Serializaiton* migration message to deprecation.

Ping: @joker-eph , because I cannot add reviewers.