### PR TITLE
Add markdown shortcode

### DIFF
--- a/website/themes/mlir/layouts/shortcodes/markdown.html
+++ b/website/themes/mlir/layouts/shortcodes/markdown.html
@@ -1,0 +1,1 @@
+{{ .Inner | markdownify }}


### PR DESCRIPTION
This adds a very simple shortcode that allows embedding markdown within HTML snippets, e.g.:

```
<div>
{{% markdown %}}
**Markdown here**
{{% /markdown %}}
</div>
```