### PR TITLE
Reduce indentation on li and ol items

### DIFF
--- a/website/themes/mlir/static/css/theme.css
+++ b/website/themes/mlir/static/css/theme.css
@@ -502,7 +502,6 @@ ul,
 ol {
   font-size: 100%;
   margin: 0;
-  margin-left: 1.5rem;
 }
 
 ul.unstyled {


### PR DESCRIPTION
Lists on the MLIR website have a very large indentation. For example, when looking at <https://mlir.llvm.org/docs/Dialects/EmitC/>, the identation is about 8 characters. By removing `margin-left`, the margin will become 0 and with that the indentation will become about 4 characters in Firefox, Safari, and Chromium-based (due to the browser's default `padding`).