### PR TITLE
Move LLVM typed pointers to past Deprecations

### DIFF
--- a/website/content/deprecation/_index.md
+++ b/website/content/deprecation/_index.md
@@ -20,16 +20,6 @@ When casting attributes or type, use the free functions variants, e.g.,
 methods in the future.
 [Discussion on Discourse](https://discourse.llvm.org/t/preferred-casting-style-going-forward/68443)
 
-### Port uses of LLVM Dialect to opaque pointers
-
-LLVM 17 has stopped officially supporting typed pointers, and MLIRs LLVM Dialect 
-is now in the process of dropping the support as well. This was announced back
-in February 2023 ([PSA](https://discourse.llvm.org/t/psa-in-tree-conversion-passes-can-now-be-used-with-llvm-opaque-pointers-please-switch-your-downstream-projects/68738))
-, and now the final steps, i.e., removing the typed pointers, have started
-([PSA](https://discourse.llvm.org/t/psa-removal-of-typed-pointers-from-the-llvm-dialect/74502)).
-If you are still targeting LLVM dialect with typed pointers, an update to
-support opaque pointers will be necessary.
-
 ## On-going Refactoring & large changes
 
 # Past Deprecation and Refactoring
@@ -84,3 +74,15 @@ For these attributes to work correctly, making registration calls to `registerNV
 `registerROCDLTargetInterfaceExternalModels` and `registerOffloadingLLVMTranslationInterfaceExternalModels` are necessary.
 
 The passes `gpu-to-(cubin|hsaco)` will be removed in a future release.
+
+## LLVM 18
+
+### Port uses of LLVM Dialect to opaque pointers
+
+LLVM 17 has stopped officially supporting typed pointers, and MLIRs LLVM Dialect 
+is now in the process of dropping the support as well. This was announced back
+in February 2023 ([PSA](https://discourse.llvm.org/t/psa-in-tree-conversion-passes-can-now-be-used-with-llvm-opaque-pointers-please-switch-your-downstream-projects/68738))
+, and now the final steps, i.e., removing the typed pointers, have started
+([PSA](https://discourse.llvm.org/t/psa-removal-of-typed-pointers-from-the-llvm-dialect/74502)).
+If you are still targeting LLVM dialect with typed pointers, an update to
+support opaque pointers will be necessary.


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/commit/4983432f17eb4b445e161c5f8278c6ea4d5d1241, typed pointers in the LLVM dialect have been completely removed and only opaque pointers supported in all of upstream. 

This completes all upstream refactoring and deprecation which is why this PR moves the text into the past deprecations and refactoring. Since the LLVM 17 release has already happened since then it was also moved to a new LLVM 18 section, warning users upgrading to LLVM 18 from 17 about the change.