### PR TITLE
Update _index.md

### DIFF
--- a/website/content/getting_started/_index.md
+++ b/website/content/getting_started/_index.md
@@ -50,8 +50,9 @@ cmake -G Ninja ../llvm \
 #  -DLLVM_CCACHE_BUILD=ON
 # Optionally, using ASAN/UBSAN can find bugs early in development, enable with:
 # -DLLVM_USE_SANITIZER="Address;Undefined" 
-# Optionally, enabling integration tests as well
-# -DMLIR_INCLUDE_INTEGRATION_TESTS=ON
+# Optionally, enabling integration tests and enable execution engine as well,
+# since tests invoke mlir-cpu-runner
+# -DMLIR_INCLUDE_INTEGRATION_TESTS=ON -DMLIR_ENABLE_EXECUTION_ENGINE=ON
 cmake --build . --target check-mlir
 ```
 


### PR DESCRIPTION
  - Document the need to specify -DMLIR_ENABLE_EXECUTION_ENGINE=ON, if -DMLIR_INCLUDE_INTEGRATION_TESTS=ON is used when configuring the build. Else mlir-cpu-runner used by mlir tests would not be built resulting in test target (check-mlir) failures.