### PR TITLE
[mlir][doc] remove trailing whitespace from MD files

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -20,7 +20,7 @@ To be notified of the next meeting, please subscribe to the
 category on Discourse.
 
 You can register to [this public calendar](https://calendar.google.com/calendar/u/0?cid=N2EzMDU3NTBjMjkzYWU5MTY5NGNlMmQ3YjJlN2JjNWEyYjViNjg1NTRmODcxOWZiOTU1MmIzNGQxYjkwNGJkZEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
-to keep up-to-date with the schedule. 
+to keep up-to-date with the schedule.
 
 If you’d like to discuss a particular topic or have questions, please add it to the
 [agenda doc](https://docs.google.com/document/d/1y2YlcOVMPocQjSFi3X6gYGRjA0onyqr41ilXji10phw/edit#).

--- a/website/content/deprecation/_index.md
+++ b/website/content/deprecation/_index.md
@@ -22,7 +22,7 @@ methods in the future.
 
 ### Port uses of LLVM Dialect to opaque pointers
 
-LLVM 17 has stopped officially supporting typed pointers, and MLIRs LLVM Dialect 
+LLVM 17 has stopped officially supporting typed pointers, and MLIRs LLVM Dialect
 is now in the process of dropping the support as well. This was announced back
 in February 2023 ([PSA](https://discourse.llvm.org/t/psa-in-tree-conversion-passes-can-now-be-used-with-llvm-opaque-pointers-please-switch-your-downstream-projects/68738))
 , and now the final steps, i.e., removing the typed pointers, have started

--- a/website/content/getting_started/Faq.md
+++ b/website/content/getting_started/Faq.md
@@ -41,7 +41,7 @@ Please do **not** cite the arXiv preprint as it is not a formal peer-reviewed
 publication.
 
 ## Why is \<small feature\> not available in MLIR?
-	
+
 On general basis, there is never a reason why a small feature is not available in MLIR other than nobody needed it enough to implement it. Consider submitting a patch. For larger features and dialects, follow the [request-for-comments](https://mlir.llvm.org/getting_started/DeveloperGuide/#guidelines-on-contributing-a-new-dialect-or-important-components) process.
 
 ## MLIR is too heavy framework, should I just reimplement my own compiler from scratch?

--- a/website/content/getting_started/_index.md
+++ b/website/content/getting_started/_index.md
@@ -49,7 +49,7 @@ cmake -G Ninja ../llvm \
 # CCache can drastically speed up further rebuilds, try adding:
 #  -DLLVM_CCACHE_BUILD=ON
 # Optionally, using ASAN/UBSAN can find bugs early in development, enable with:
-# -DLLVM_USE_SANITIZER="Address;Undefined" 
+# -DLLVM_USE_SANITIZER="Address;Undefined"
 # Optionally, enabling integration tests as well
 # -DMLIR_INCLUDE_INTEGRATION_TESTS=ON
 cmake --build . --target check-mlir

--- a/website/content/getting_started/openprojects.md
+++ b/website/content/getting_started/openprojects.md
@@ -29,14 +29,8 @@ starting on these projects.
 * TableGen "front-end dialect" (mentor: Jacques Pienaar)
 * Making MLIR interact with existing polyhedral tools: isl, pluto (mentor: Alex Zinenko)
 * MLIR visualization (mentor: Jacques Pienaar)
-* MLIR sparse compiler [starter tasks](https://github.com/llvm/llvm-project/labels/mlir%3Asparse) (mentor: Aart Bik)
-
-  MLIR allows for representing multiple levels of abstraction all together in the same IR/function. Visualizing MLIR modules therefore requires going beyond visualizing a graph of nodes all at the same level (which is not trivial in and of itself!), nor is it specific to Machine Learning. Beyond visualizing a MLIR module, there is also visualizing MLIR itself that is of interest. In particular, visualizing the rewrite rules, visualizing the matching process (including the failure to match, sort of like https://www.debuggex.com/ but for declarative rewrites), considering effects of rewrites over time, etc.
-
-  The visualizations should all be built with open source components but whether standalone (e.g., combining with, say, GraphViz to generate offline images) or dynamic tools (e.g., displayed in browser) is open for discussion. It should be usable completely offline in either case.
-	
-	We will be working with interested students to refine the exact project based on interests given the wide scope of potential approaches. And open to proposals within this general area.
-
+* MLIR sparsifier (aka sparse compiler) [starter tasks](https://github.com/llvm/llvm-project/labels/mlir%3Asparse) (mentor: Aart Bik)
+* MLIR allows for representing multiple levels of abstraction all together in the same IR/function. Visualizing MLIR modules therefore requires going beyond visualizing a graph of nodes all at the same level (which is not trivial in and of itself!), nor is it specific to Machine Learning. Beyond visualizing a MLIR module, there is also visualizing MLIR itself that is of interest. In particular, visualizing the rewrite rules, visualizing the matching process (including the failure to match, sort of like https://www.debuggex.com/ but for declarative rewrites), considering effects of rewrites over time, etc. The visualizations should all be built with open source components but whether standalone (e.g., combining with, say, GraphViz to generate offline images) or dynamic tools (e.g., displayed in browser) is open for discussion. It should be usable completely offline in either case. We will be working with interested students to refine the exact project based on interests given the wide scope of potential approaches. And open to proposals within this general area.
 * Rewrite patterns expressed in MLIR (mentor: Jacques Pienaar)
 * Generic value range analysis for MLIR (mentor: River Riddle)
 
@@ -45,12 +39,11 @@ starting on these projects.
 This is section for projects that have not yet started but there are
 individuals/groups intending to start work on in near future.
 
-* Rework the MLIR python bindings, add a C APIs for core concepts (mentor: 
+* Rework the MLIR python bindings, add a C APIs for core concepts (mentor:
   Nicolas Vasilache, Alex Zinenko)
 * [bugpoint/llvm-reduce](https://llvm.org/docs/BugpointRedesign.html) kind
   of tools for MLIR (mentor: Mehdi Amini, Jacques Pienaar)
 * MLIR visualization, there are some projects in flight but we unfortunately
   don't know the project plans of those teams. But if you intend to work on
-	something in this area it would be good to discuss on the forum early
-	in case there are collaboration opportunity.
-  
+  something in this area it would be good to discuss on the forum early
+  in case there are collaboration opportunity.

--- a/website/content/talks/_index.md
+++ b/website/content/talks/_index.md
@@ -78,7 +78,7 @@ to discuss a particular topic or have questions, please add it to the
 
 The meetings are announced on [Discourse](https://discourse.llvm.org/c/mlir/mlir-announcements/44),
 subscribing to this category is the best way to stay informed. You can also register
-to [this public calendar](https://calendar.google.com/calendar/u/0?cid=N2EzMDU3NTBjMjkzYWU5MTY5NGNlMmQ3YjJlN2JjNWEyYjViNjg1NTRmODcxOWZiOTU1MmIzNGQxYjkwNGJkZEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t). 
+to [this public calendar](https://calendar.google.com/calendar/u/0?cid=N2EzMDU3NTBjMjkzYWU5MTY5NGNlMmQ3YjJlN2JjNWEyYjViNjg1NTRmODcxOWZiOTU1MmIzNGQxYjkwNGJkZEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
 
 
 ### About MLIR and MLIR Components

--- a/website/content/users/_index.md
+++ b/website/content/users/_index.md
@@ -23,9 +23,9 @@ Beaver provides a simple, intuitive, and extensible interface for MLIR.
 ## [Bᴛᴏʀ2ᴍʟɪʀ](https://github.com/jetafese/btor2mlir): A Format and Toolchain for Hardware Verification
 
 Bᴛᴏʀ2ᴍʟɪʀ applies MLIR to the domain of hardware verification by offering a clean way to take advantage of a format's
-strengths. For example, we support the use of software verification methods for hardware 
-verification problems represented in the Bᴛᴏʀ2 format. The project aims to spur and support research 
-in the formal verification domain, and has been shown to be competitive with existing methods. 
+strengths. For example, we support the use of software verification methods for hardware
+verification problems represented in the Bᴛᴏʀ2 format. The project aims to spur and support research
+in the formal verification domain, and has been shown to be competitive with existing methods.
 
 ## [Catalyst](https://github.com/PennyLaneAI/catalyst)
 


### PR DESCRIPTION
Also added "sparsifier" for "sparse compiler" in one open projects page, and reformatted the projects so that it is more clear where the next one begins