### PR TITLE
Overhaul TestingGuide page

### DIFF
--- a/website/content/getting_started/TestingGuide.md
+++ b/website/content/getting_started/TestingGuide.md
@@ -266,7 +266,7 @@ emulator>` denotes the path to the installed emulator binary. `sh cmake -G Ninja
 tests run as shown earlier, but will now include the indicated emulated tests as
 well.
 
-### Unit tests
+### C++ Unit tests
 
 Unit tests are written using the
 [googletest](https://google.github.io/googletest/) framework and are located in

--- a/website/content/getting_started/TestingGuide.md
+++ b/website/content/getting_started/TestingGuide.md
@@ -10,7 +10,7 @@ weight: 40
 ## Quickstart commands
 
 These commands are explained below in more detail. All commands are run from the
-cmake build directory `build/`.
+cmake build directory `build/`, after [building the project](/getting_started/).
 
 ### Run all MLIR tests:
 

--- a/website/content/getting_started/TestingGuide.md
+++ b/website/content/getting_started/TestingGuide.md
@@ -87,7 +87,7 @@ pattern appears in the output.
 
 The above test asserts that, after running Common Subexpression Elimination
 (`-cse`), only one constant remains in the IR, and the sole SSA value is
-returned twice from th function.
+returned twice from the function.
 
 #### Build system details
 

--- a/website/content/getting_started/TestingGuide.md
+++ b/website/content/getting_started/TestingGuide.md
@@ -274,7 +274,7 @@ should be accompanied by a corresponding diagnostic test.
 
 When you cannot use the above,
 such as for testing a non-user-facing API like a data structure,
-then you should write unit tests.
+then you may write C++ unit tests.
 This is preferred because the C++ APIs are not stable and subject to frequent refactoring.
 Using `lit` and `FileCheck` allows maintainers to improve the MLIR internals more easily.
 

--- a/website/content/getting_started/TestingGuide.md
+++ b/website/content/getting_started/TestingGuide.md
@@ -5,32 +5,66 @@ draft: false
 weight: 40
 ---
 
-Testing is an integral part of any software infrastructure. In general, all
-commits to the MLIR repository should include an accompanying test of some form.
-Commits that include no functional changes, such as API changes like symbol
-renaming, should be tagged with NFC(no functional changes). This signals to the
-reviewer why the change doesn't/shouldn't include a test.
+{{< toc >}}
 
-MLIR generally separates testing into three main categories, [Check](#check-tests)
-tests, [Unit](#unit-tests) tests, and [Integration](#integration-tests) tests.
+## Quickstart commands
 
-## Check tests
+These commands are explained below in more detail.
 
-Check tests are tests that verify that some set of string tags appear in the
-output of some program. These tests generally encompass anything related to the
-state of the IR (and more); analysis, parsing, transformation, verification,
-etc. They are written utilizing several different tools:
+### Run the main MLIR test suite:
 
-### FileCheck tests
+```sh
+cmake --build . --target check-mlir
+```
 
-[FileCheck](https://llvm.org/docs/CommandGuide/FileCheck.html) is a utility tool
-that "reads two files (one from standard input, and one specified on the command
-line) and uses one to verify the other." Essentially, one file contains a set of
-tags that are expected to appear in the output file. MLIR utilizes FileCheck, in
-combination with [lit](https://llvm.org/docs/CommandGuide/lit.html), to verify
-different aspects of the IR - such as the output of a transformation pass.
+### Run integration tests (requires `-DMLIR_INCLUDE_INTEGRATION_TESTS=ON`):
 
-An example FileCheck test is shown below:
+```sh
+cmake --build . --target check-mlir-integration
+```
+
+### Run C++ unit tests:
+
+```sh
+cmake --build . --target check-mlir-unit
+```
+
+### Run `lit` tests in a specific directory
+
+```sh
+# from build/
+# -v shows output of failed tests
+bin/llvm-lit -v tools/mlir/test/Dialect/Arithmetic
+```
+
+### Run a specific `lit` test file
+
+```sh
+# from build/
+# -v shows output of failed tests
+bin/llvm-lit -v tools/mlir/test/Dialect/Polynomial/ops.mlir
+```
+
+## Test categories
+
+### `lit` and `FileCheck` tests
+
+[`FileCheck`](https://llvm.org/docs/CommandGuide/FileCheck.html) is a tool that
+"reads two files (one from standard input, and one specified on the command
+line) and uses one to verify the other." One file contains a set of `CHECK`
+tags that specify strings and patterns expected to appear in the other file.
+MLIR utilizes `FileCheck`, in combination with
+[`lit`](https://llvm.org/docs/CommandGuide/lit.html), to verify different
+aspects of the IR—such as the output of a transformation pass.
+
+The source files of `lit`/`FileCheck` tests are organized within the `mlir`
+source tree under `mlir/test/`. Within this directory, tests are organized
+roughly mirroring `mlir/include/mlir/`, including subdirectories for
+`Dialect/`, `Transforms/`, `Conversion/`, etc.
+
+#### Example
+
+An example `FileCheck` test is shown below:
 
 ```mlir
 // RUN: mlir-opt %s -cse | FileCheck %s
@@ -46,10 +80,205 @@ func.func @simple_constant() -> (i32, i32) {
 }
 ```
 
-The above test performs a check that after running Common Sub-Expression
-elimination, only one constant remains in the IR.
+A comment with `RUN` represents a `lit` directive specifying a command line
+invocation to run, with special substitutions like `%s` for the current file. A
+comment with `CHECK` represents a `FileCheck` directive to assert a string or
+pattern appears in the output.
 
-#### FileCheck best practices
+The above test asserts that, after running Common Subexpression Elimination
+(`-cse`), only one constant remains in the IR, and the sole SSA value is
+returned twice from th function.
+
+#### Build system details
+
+While developing in MLIR, it is common to run parts of the test suite many
+times. While invoking the `check-mlir` target is a nice shortcut, the
+interaction with the build system can be confusing. Since most people don't
+understand how all of this is put together in the build system, this section
+attempts to demystify how to operate the testing tools independently.
+
+Invoking the `check-mlir` target is roughly equivalent to running (from the
+build directory):
+
+```shell
+./bin/llvm-lit tools/mlir/test
+```
+
+See the [Lit Documentation](https://llvm.org/docs/CommandGuide/lit.html) for a
+description of all options.
+
+Subsets of the testing tree can be invoked by passing a more specific path
+instead of `tools/mlir/test` above. Example:
+
+```shell
+./bin/llvm-lit tools/mlir/test/Dialect/Arithmetic
+
+# Note that it is possible to test at the file granularity, but since these
+# files do not actually exist in the build directory, you need to know the
+# name.
+./bin/llvm-lit tools/mlir/test/Dialect/Arithmetic/ops.mlir
+```
+
+Lit has a number of options that control test execution. Here are some of the
+most useful for development purposes:
+
+* [`--filter=REGEXP`](https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-filter) :
+  Only runs tests whose name matches the REGEXP. Can also be specified via
+  the `LIT_FILTER` environment variable.
+* [`--filter-out=REGEXP`](https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-filter-out) :
+  Filters out tests whose name matches the REGEXP. Can also be specified via
+  the `LIT_FILTER_OUT` environment variable.
+* [`-a`](https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-a) : Shows
+  all information (useful while iterating on a small set of tests).
+* [`--time-tests`](https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-time-tests) :
+  Prints timing statistics about slow tests and overall histograms.
+
+Any Lit options can be set in the `LIT_OPTS` environment variable. This is
+especially useful when using the build system target `check-mlir`.
+
+Examples:
+
+```
+# Only run tests that have "python" in the name and print all invocations.
+LIT_OPTS="--filter=python -a" cmake --build . --target check-mlir
+
+# Only run the array_attributes python test, using the LIT_FILTER mechanism.
+LIT_FILTER="python/ir/array_attributes" cmake --build . --target check-mlir
+
+# Run everything except for example and integration tests (which are both
+# somewhat slow).
+LIT_FILTER_OUT="Examples|Integrations" cmake --build . --target check-mlir
+```
+
+Note that the above use the generic cmake command for invoking the `check-mlir`
+target, but you can typically use the generator directly to be more concise
+(i.e. if configured for `ninja`, then `ninja check-mlir` can replace the
+`cmake --build . --target check-mlir` command). We use generic `cmake`
+commands in documentation for consistency, but being concise is often better
+for interactive workflows.
+
+### Diagnostic tests
+
+MLIR provides rich source location tracking that can be used to emit errors,
+warnings, etc. from anywhere throughout the codebase, which are jointly called
+_diagnostics_. Diagnostic tests assert that specific diagnostic messages are
+emitted for a given input program. These tests are useful in that they allow
+checking specific invariants of the IR without transforming or changing
+anything.
+
+Some examples of tests in this category are:
+
+ - Verifying invariants of operations
+ - Checking the expected results of an analysis
+ - Detecting malformed IR
+
+Diagnostic verification tests are written utilizing the
+[source manager verifier handler](../docs/Diagnostics#sourcemgr-diagnostic-verifier-handler),
+which is enabled via the `verify-diagnostics` flag in `mlir-opt`.
+
+An example .mlir test running under `mlir-opt` is shown below:
+
+```mlir
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics
+
+// Expect an error on the same line.
+func.func @bad_branch() {
+  cf.br ^missing  // expected-error {{reference to an undefined block}}
+}
+
+// -----
+
+// Expect an error on an adjacent line.
+func.func @foo(%a : f32) {
+  // expected-error@+1 {{invalid predicate attribute specification: "foo"}}
+  %result = arith.cmpf "foo", %a, %a : f32
+  return
+}
+```
+
+### Integration tests
+
+Integration tests are `FileCheck` tests that verify functional correctness
+of MLIR code by running it, usually by means of JIT compilation using
+`mlir-cpu-runner` and runtime support libraries.
+
+Integration tests don't run by default. To enable them, set the
+`-DMLIR_INCLUDE_INTEGRATION_TESTS=ON` flag during `cmake` configuration as
+described in [Getting Started](_index.md).
+
+```sh
+cmake -G Ninja ../llvm \
+   ... \
+   -DMLIR_INCLUDE_INTEGRATION_TESTS=ON \
+   ...
+```
+
+Now the integration tests run as part of regular testing.
+
+```sh
+cmake --build . --target check-mlir
+```
+
+To run only the integration tests, run the `check-mlir-integration` target.
+
+```sh
+cmake --build . --target check-mlir-integration
+```
+
+The source files of the integration tests are organized within the `mlir`
+source tree by dialect (for example, `test/Integration/Dialect/Vector`).
+
+#### Hardware emulators
+
+The integration tests include some tests for targets that are not widely
+available yet, such as specific AVX512 features (like `vp2intersect`)
+and the Intel AMX instructions. These tests require an emulator to
+run correctly (lacking real hardware, of course). To enable these specific
+tests, first download and install the
+[Intel Emulator](https://software.intel.com/content/www/us/en/develop/articles/intel-software-development-emulator.html).
+Then, include the following additional configuration flags in the initial
+set up (X86Vector and AMX can be individually enabled or disabled), where
+`<path to emulator>` denotes the path to the installed emulator binary.
+```sh
+cmake -G Ninja ../llvm \
+   ... \
+   -DMLIR_INCLUDE_INTEGRATION_TESTS=ON \
+   -DMLIR_RUN_X86VECTOR_TESTS=ON \
+   -DMLIR_RUN_AMX_TESTS=ON \
+   -DINTEL_SDE_EXECUTABLE=<path to emulator> \
+   ...
+```
+After this one-time set up, the tests run as shown earlier, but will
+now include the indicated emulated tests as well.
+
+### Unit tests
+
+Unit tests are written using the
+[googletest](https://google.github.io/googletest/) framework and are located in
+the `mlir/unittests/` directory.
+
+## Contributor guidelines
+
+In general, all
+commits to the MLIR repository should include an accompanying test of some form.
+Commits that include no functional changes, such as API changes like symbol
+renaming, should be tagged with NFC (No Functional Changes). This signals to the
+reviewer why the change doesn't/shouldn't include a test.
+
+`lit` tests with `FileCheck` are the preferred method of testing in MLIR
+for non-erroneous output verification.
+
+Diagnostic tests are the preferred method of asserting error messages are
+output correctly. Every user-facing error message (e.g., `op.emitError()`)
+should be accompanied by a corresponding diagnostic test.
+
+When you cannot use the above,
+such as for testing a non-user-facing API like a data structure,
+then you should write unit tests.
+This is preferred because the C++ APIs are not stable and subject to frequent refactoring.
+Using `lit` and `FileCheck` allows maintainers to improve the MLIR internals more easily.
+
+### FileCheck best practices
 
 FileCheck is an extremely useful utility, it allows for easily matching various
 parts of the output. This ease of use means that it becomes easy to write
@@ -129,172 +358,3 @@ func.func @simple_constant() -> (i32, i32) {
   return %0, %1 : i32, i32
 }
 ```
-
-### Diagnostic verification tests
-
-MLIR provides rich source location tracking that can be used to emit errors,
-warnings, etc. easily from anywhere throughout the codebase. Certain classes of
-tests are written to check that certain diagnostics are emitted for a given
-input program, such as an MLIR file. These tests are useful in that they allow
-checking specific invariants of the IR without transforming or changing
-anything. Some examples of tests in this category are: those that verify
-invariants of operations, or check the expected results of an analysis.
-Diagnostic verification tests are written utilizing the
-[source manager verifier handler](../docs/Diagnostics#sourcemgr-diagnostic-verifier-handler),
-accessible via the `verify-diagnostics` flag in mlir-opt.
-
-An example .mlir test running under `mlir-opt` is shown below:
-
-```mlir
-// RUN: mlir-opt %s -split-input-file -verify-diagnostics
-
-// Expect an error on the same line.
-func.func @bad_branch() {
-  cf.br ^missing  // expected-error {{reference to an undefined block}}
-}
-
-// -----
-
-// Expect an error on an adjacent line.
-func.func @foo(%a : f32) {
-  // expected-error@+1 {{invalid predicate attribute specification: "foo"}}
-  %result = arith.cmpf "foo", %a, %a : f32
-  return
-}
-```
-
-## Unit tests
-
-Unit tests are written using
-[Google Test](https://github.com/google/googletest/blob/master/googletest/docs/primer.md)
-and are located in the unittests/ directory. Tests of these form *should* be
-limited to API tests that cannot be reasonably written as [Check](#check-tests)
-tests, e.g. those for data structures. It is important to keep in mind that the
-C++ APIs are not stable, and evolve over time. As such, directly testing the C++
-IR interfaces makes the tests more fragile as those C++ APIs evolve over time.
-This makes future API refactorings, which may happen frequently, much more
-cumbersome as the number of tests scale.
-
-To run the unit tests after building MLIR:
-
-```sh
-cmake --build . --target check-mlir-unit
-```
-
-## Integration tests
-
-Integration tests are check tests that verify the output of MLIR code running
-"end-to-end", usually by means of JIT compilation using the `mlir-cpu-runner`
-utility and small runtime support library that facilates I/O. The integration
-tests in MLIR don't run by default, but need to be explicitly enabled during
-the initial set up described in [Getting Started](_index.md) with an
-additional configuration flag.
-```sh
-cmake -G Ninja ../llvm \
-   ... \
-   -DMLIR_INCLUDE_INTEGRATION_TESTS=ON \
-   ...
-```
-After this one-time set up, the tests run as part of regular testing as follows.
-```sh
-cmake --build . --target check-mlir
-```
-Alternatively, to just run the integration tests, the following command can be
-used.
-```sh
-cmake --build . --target check-mlir-integration
-```
-
-The source files of the integration tests are organized within the `mlir` source
-tree by dialect (for example, `test/Integration/Dialect/Vector`).
-
-### Emulator
-
-The integration tests include some tests for targets that are not widely
-available yet, such as specific AVX512 features (like `vp2intersect`)
-and the Intel AMX instructions. These tests require an emulator to
-run correctly (lacking real hardware, of course). To enable these specific
-tests, first download and install the
-[Intel Emulator](https://software.intel.com/content/www/us/en/develop/articles/intel-software-development-emulator.html).
-Then, include the following additional configuration flags in the initial
-set up (X86Vector and AMX can be individually enabled or disabled), where
-`<path to emulator>` denotes the path to the installed emulator binary.
-```sh
-cmake -G Ninja ../llvm \
-   ... \
-   -DMLIR_INCLUDE_INTEGRATION_TESTS=ON \
-   -DMLIR_RUN_X86VECTOR_TESTS=ON \
-   -DMLIR_RUN_AMX_TESTS=ON \
-   -DINTEL_SDE_EXECUTABLE=<path to emulator> \
-   ...
-```
-After this one-time set up, the tests run as shown earlier, but will
-now include the indicated emulated tests as well.
-
-## Command Line Incantations
-
-While developing in MLIR, it is common to run parts of the test suite many
-times. While invoking the `check-mlir` target is a nice shortcut, the
-interaction with the build system can be confusing. Since most people don't
-understand how all of this is put together in the build system, this section
-attempts to demystify how to operate the testing tools independently.
-
-Invoking the `check-mlir` target is roughly equivalent to running (from the
-build directory):
-
-```shell
-./bin/llvm-lit tools/mlir/test
-```
-
-See the [Lit Documentation](https://llvm.org/docs/CommandGuide/lit.html) for a
-description of all options.
-
-Subsets of the testing tree can be invoked by passing a more specific path
-instead of `tools/mlir/test` above. Example:
-
-```shell
-./bin/llvm-lit tools/mlir/test/Dialect/Arithmetic
-
-# Note that it is possible to test at the file granularity, but since these
-# files do not actually exist in the build directory, you need to know the
-# name.
-./bin/llvm-lit tools/mlir/test/Dialect/Arithmetic/ops.mlir
-```
-
-Lit has a number of options that control test execution. Here are some of the
-most useful for development purposes:
-
-* [`--filter=REGEXP`](https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-filter) :
-  Only runs tests whose name matches the REGEXP. Can also be specified via
-  the `LIT_FILTER` environment variable.
-* [`--filter-out=REGEXP`](https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-filter-out) :
-  Filters out tests whose name matches the REGEXP. Can also be specified via
-  the `LIT_FILTER_OUT` environment variable.
-* [`-a`](https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-a) : Shows
-  all information (useful while iterating on a small set of tests).
-* [`--time-tests`](https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-time-tests) :
-  Prints timing statistics about slow tests and overall histograms.
-
-Any Lit options can be set in the `LIT_OPTS` environment variable. This is
-especially useful when using the build system target `check-mlir`.
-
-Examples:
-
-```
-# Only run tests that have "python" in the name and print all invocations.
-LIT_OPTS="--filter=python -a" cmake --build . --target check-mlir
-
-# Only run the array_attributes python test, using the LIT_FILTER mechanism.
-LIT_FILTER="python/ir/array_attributes" cmake --build . --target check-mlir
-
-# Run everything except for example and integration tests (which are both
-# somewhat slow).
-LIT_FILTER_OUT="Examples|Integrations" cmake --build . --target check-mlir
-```
-
-Note that the above use the generic cmake command for invoking the `check-mlir`
-target, but you can typically use the generator directly to be more concise
-(i.e. if configured for `ninja`, then `ninja check-mlir` can replace the
-`cmake --build . --target check-mlir` command). We use generic `cmake`
-commands in documentation for consistency, but being concise is often better
-for interactive workflows.


### PR DESCRIPTION
@joker-eph 

The main change is to separate the doc into logical sections for:

- Quick command reference
- Description of the different test types (what)
- Contributor guidelines (how and why)