### PR TITLE
Remove AMDGPU and NVPTX backend from GettingStarted

### DIFF
--- a/website/content/getting_started/_index.md
+++ b/website/content/getting_started/_index.md
@@ -41,7 +41,7 @@ cd llvm-project/build
 cmake -G Ninja ../llvm \
    -DLLVM_ENABLE_PROJECTS=mlir \
    -DLLVM_BUILD_EXAMPLES=ON \
-   -DLLVM_TARGETS_TO_BUILD="Native;NVPTX;AMDGPU" \
+   -DLLVM_TARGETS_TO_BUILD="Native" \
    -DCMAKE_BUILD_TYPE=Release \
    -DLLVM_ENABLE_ASSERTIONS=ON
 # Using clang and lld speeds up the build, we recommend adding:


### PR DESCRIPTION
These backends take a long time to build, and unless there is a reason, they should not be in the getting started guide. Including these backends should count in Advanced Usage.