### PR TITLE
Add notice about the removal of `vector.reshape`

### DIFF
--- a/website/content/deprecation/_index.md
+++ b/website/content/deprecation/_index.md
@@ -93,3 +93,13 @@ support opaque pointers will be necessary.
 ### Removal of `gpu-to-(cubin|hsaco)` in favor of GPU compilation attributes
 
 **Notice: The passes `gpu-to-(cubin|hsaco)` have been removed from the monorepo, use target attributes instead. See the LLVM 17 section on this page for more information.**
+
+## LLVM 20
+
+### Removal of `vector.reshape`
+
+This operation was added back in 2019, and since then, no lowerings or uses have
+been implemented in upstream MLIR or any known downstream projects. Due to this
+lack of use, it was decided that the operation should be removed.
+
+[Discussion on Discourse](https://discourse.llvm.org/t/rfc-should-vector-reshape-be-removed/80478)


### PR DESCRIPTION
See related PR: https://github.com/llvm/llvm-project/pull/101645