### PR TITLE
Fix duplicated CMAKE_BUILD_TYPE in Windows build instructions

### DIFF
--- a/website/content/getting_started/_index.md
+++ b/website/content/getting_started/_index.md
@@ -76,6 +76,6 @@ REM invoked.
 git clone https://github.com/llvm/llvm-project.git
 mkdir llvm-project\build
 cd llvm-project\build
-cmake ..\llvm -G "Visual Studio 15 2017 Win64" -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_BUILD_EXAMPLES=ON -DLLVM_TARGETS_TO_BUILD="Native" -DCMAKE_BUILD_TYPE=Release -Thost=x64 -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
+cmake ..\llvm -G "Visual Studio 15 2017 Win64" -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_BUILD_EXAMPLES=ON -DLLVM_TARGETS_TO_BUILD="Native" -DCMAKE_BUILD_TYPE=Release -Thost=x64 -DLLVM_ENABLE_ASSERTIONS=ON
 cmake --build . --target tools/mlir/test/check-mlir
 ```


### PR DESCRIPTION
Fixed the issue #201 