### PR TITLE
Add a page about governance / area team

### DIFF
--- a/website/content/governance/_index.md
+++ b/website/content/governance/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Governance"
+date: 2025-04-08T16:28:24Z
+draft: false
+weight: 1
+---
+
+MLIR is part of the LLVM project and is subject to its [governance rules](https://github.com/llvm/llvm-www/blob/main/proposals/LP0004-project-governance.md). As an important LLVM subproject, MLIR has a dedicated area team whose main role is to facilitate decision-making within the project, in particular by nominating maintainers.
+
+As of 2025, the area team consists of:
+
+ - [Alex Zinenko](https://github.com/ftynse/) (chair)
+ - [Renato Golin](https://github.com/rengolin/) (secretary)
+ - [Jacques Pienaar](https://github.com/jpienaar)
+ - [Matthias Springer](https://github.com/matthias-springer/)
+
+Members of the area team are also members of the project community at large and the preferred method of contacting them are through the usual community channels.


### PR DESCRIPTION
This is easier to find that deep in Discourse