### PR TITLE
Advertise Markdown files in `website/content/` as "source" files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+website/content/**/*.md linguist-detectable


### PR DESCRIPTION
According to README:
> The source pages are written in Markdown format under the `website/content` folder.

This change aims to reflect that in language stats:
|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/b81f7ce1-b15f-4f90-aaf3-a6e1e304a081)|![image](https://github.com/user-attachments/assets/21a1c747-a5bd-4d48-b506-ab589592ebca)|
|![image](https://github.com/user-attachments/assets/f6c097c7-d3e6-4b20-a05c-43892a9141e4)|![image](https://github.com/user-attachments/assets/08e5d50b-7029-4879-9d94-9aec5974cf68)|

In my opinion, properly detecting Markdown as the dominant language of the repository will help people (e.g. documentation writers and beginner programmers) to find a project to contribute to.