### PR TITLE
Add Allo to users of MLIR

### DIFF
--- a/website/content/users/_index.md
+++ b/website/content/users/_index.md
@@ -14,6 +14,14 @@ hand-writing Assembly code. With Accera, these problems and impediments can be
 addressed in an optimized way. It is available as a Python library and supports
 cross-compiling to a wide range of processor targets.
 
+## [Allo](https://github.com/cornell-zhang/allo)
+
+Allo is a Python-embedded Accelerator Design Language (ADL) and compiler that
+facilitates the construction of large-scale, high-performance hardware accelerators
+in a modular and composable manner. It supports progressive hardware customizations,
+reusable parameterized kernel templates, and composable schedules on top of MLIR
+for productive hardware development.
+
 ## [Beaver](https://github.com/beaver-lodge/beaver)
 
 Beaver is an MLIR frontend in Elixir and Zig.


### PR DESCRIPTION
> [Allo](https://github.com/cornell-zhang/allo) is a Python-embedded Accelerator Design Language (ADL) and compiler that
facilitates the construction of large-scale, high-performance hardware accelerators
in a modular and composable manner. It supports progressive hardware customizations,
reusable parameterized kernel templates, and composable schedules on top of MLIR
for productive hardware development.

We gave a talk at the [MLIR Open Design Meeting](https://mlir.llvm.org/talks/) on 2022-08-11 about our progress, and the project was finally published in [PLDI 2024](https://dl.acm.org/doi/10.1145/3656401). Since then, Allo has attracted over 10 industry and academic partners, thanks to its strong foundation on MLIR.