### PR TITLE
Notification and Discourse link for vector.splat deprecation

### DIFF
--- a/website/content/deprecation/_index.md
+++ b/website/content/deprecation/_index.md
@@ -17,6 +17,13 @@ up with MLIR development.
 The `match` and `rewrite` functions of `RewritePattern` and `ConversionPattern`
 are deprecated. Use the combined `matchAndRewrite` instead.
 
+
+### Use `vector.broadcast` instead of `vector.splat`
+
+The `vector.splat` operation has been deprecated.
+
+[Discussion on Discourse](https://discourse.llvm.org/t/rfc-mlir-vector-deprecate-then-remove-vector-splat/87143)
+
 ## On-going Refactoring & large changes
 
 # Past Deprecation and Refactoring


### PR DESCRIPTION
There are other ops that are deprecated in this dialect that could also be added here (extractelement, insertelement), happy to add if requested. 