### PR TITLE
Update doxygen from 1.9 to 1.14 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,11 @@ jobs:
       run: ./mlir-www-helper.sh --help
 
     - name: Install dependencies
-      run: sudo apt-get install doxygen graphviz python3
+      run: |
+        sudo apt-get install graphviz python3
+        wget https://github.com/doxygen/doxygen/releases/download/Release_1_14_0/doxygen-1.14.0.linux.bin.tar.gz -O /tmp/doxygen.tar.gz
+        tar -xvf /tmp/doxygen.tar.gz
+        echo "$(pwd)/doxygen-1.14.0/bin" >> $GITHUB_PATH
 
     - name: Clone LLVM repo
       uses: actions/checkout@v3


### PR DESCRIPTION
Currently, we use Doxygen 1.9 to generate the MLIR documentation, which is quite outdated. In the newer Doxygen 1.14 release, the generated HTML pages have a much more modern look, compared to the rather “90s-style” design of the older versions. (See the [1.14 changelog](https://doxygen.nl/manual/changelog.html#log_1_14) for more details.)

It also appears that LLVM and Clang have already upgraded to Doxygen 1.14, as indicated at the bottom right corner of their [online documentation](https://llvm.org/doxygen/).

