### PR TITLE
Add an entry in navigation bar for python bindings docs

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -92,6 +92,12 @@ disablePathToLower = true
     url = "/doxygen/"
 
 [[menu.main]]
+    name = "Python Bindings API docs"
+    parent = "Source"
+    weight = 3
+    url = "/python-bindings/"
+
+[[menu.main]]
     name = "Bugs"
     weight = 20
     url = "https://github.com/llvm/llvm-project/issues?q=is%3Aissue%20state%3Aopen%20label%3Amlir"


### PR DESCRIPTION
This is a follow-up PR of #235.

This PR adds a button in the navigation bar for the python bindings API docs (https://mlir.llvm.org/python-bindings/), so that users can find the generated Sphinx docs.

cc @jpienaar 