### PR TITLE
Add MLIR code block highlighting to python bindings docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         cd sphinx-mlir-python
         pip install -r requirements.txt
-        make html
+        SPHINX_LLVM_SRC_PATH=$(pwd)/../llvm_src make html
         cp -r _build/html ../website/static/python-bindings
 
     - name: Build pattern search index

--- a/sphinx-mlir-python/_static/ignore_highlight_err.css
+++ b/sphinx-mlir-python/_static/ignore_highlight_err.css
@@ -1,0 +1,7 @@
+.highlight .err,
+.highlight .err * {
+  background: transparent !important;
+  color: inherit !important;
+  border: none !important;
+  box-shadow: none !important;
+}

--- a/sphinx-mlir-python/conf.py
+++ b/sphinx-mlir-python/conf.py
@@ -50,6 +50,22 @@ def prepare_docstring(doc):
     return rst
 _autoapi_parser._prepare_docstring = prepare_docstring
 
+html_static_path = ['_static']
+html_css_files = [
+  'ignore_highlight_err.css',
+]
+
+if llvm_path := os.environ.get("SPHINX_LLVM_SRC_PATH"):
+    import sphinx.highlighting as _hl
+    import importlib
+
+    # load the lexer module
+    lexer_path = llvm_path + "/mlir/utils/pygments/mlir_lexer.py"
+    lexer_spec = importlib.util.spec_from_file_location("mlir_lexer", lexer_path)
+    lexer_module = importlib.util.module_from_spec(lexer_spec)
+    lexer_spec.loader.exec_module(lexer_module)
+
+    _hl.lexers["mlir"] = lexer_module.MlirLexer()
 
 # generate an index page for the mlir namespace
 def ensure_mlir_index(_):


### PR DESCRIPTION
As mentioned in https://github.com/llvm/mlir-www/pull/239#issuecomment-3483825724, currently many MLIR code blocks in the Python bindings’ Sphinx documentation are missing syntax highlighting.
 Sphinx uses the [Pygments](https://github.com/pygments/pygments) library for lexical analysis and syntax highlighting, but Pygments doesn’t include a built-in lexer for MLIR.

In this PR, we leverage https://github.com/llvm/llvm-project/blob/main/mlir/utils/pygments/mlir_lexer.py (interestingly, the LLVM repository already contains a Pygments lexer for MLIR) and integrate it into the Sphinx setup.

Before:
<img width="1496" height="685" alt="image" src="https://github.com/user-attachments/assets/90ef57ca-9a59-4039-9e42-34a04eda494d" />

After:
<img width="1482" height="658" alt="image" src="https://github.com/user-attachments/assets/a7b0c52e-3735-480f-9321-59268517bca4" />


You can preview this change at https://mlir-python-hl.surge.sh/.

cc @jpienaar @makslevental 