### PR TITLE
Fix rendering of google-style docstring in sphinx docs

### DIFF
--- a/sphinx-mlir-python/conf.py
+++ b/sphinx-mlir-python/conf.py
@@ -38,16 +38,26 @@ autoapi_python_use_implicit_namespaces = True
 
 import autoapi._parser as _autoapi_parser
 import commonmark
+from sphinx.ext.napoleon.docstring import GoogleDocstring
 
+# Check if the docstring is google-style.
+# NOTE: It is pretty minimal but enough to cover current cases in MLIR Python.
+def is_google_docstring(doc):
+    return any(x in doc for x in ["Args:\n", "Returns:\n", "Raises:\n"])
 
-# hook the _prepare_docstring function in sphinx-autoapi,
+# Hook the _prepare_docstring function in sphinx-autoapi,
 # so that we can convert markdown to rst.
 _prepare_docstring = _autoapi_parser._prepare_docstring
 def prepare_docstring(doc):
-    md = _prepare_docstring(doc)
-    ast = commonmark.Parser().parse(md)
-    rst = commonmark.ReStructuredTextRenderer().render(ast)
-    return rst
+    docstring = _prepare_docstring(doc)
+    if is_google_docstring(docstring):
+        # convert google-style docstring to rst
+        docstring = str(GoogleDocstring(docstring))
+    else:
+        # convert markdown to rst
+        ast = commonmark.Parser().parse(docstring)
+        docstring = commonmark.ReStructuredTextRenderer().render(ast)
+    return docstring
 _autoapi_parser._prepare_docstring = prepare_docstring
 
 html_static_path = ['_static']


### PR DESCRIPTION
Context of this PR: https://github.com/llvm/llvm-project/pull/167063#issuecomment-3505859872

The current MLIR Python Sphinx documentation cannot handle functions that use Google-style docstrings. In this PR, we introduce support for this feature, allowing Google-style docstrings to be properly converted into reStructuredText.

Before:
<img width="1490" height="1147" alt="image" src="https://github.com/user-attachments/assets/79e99552-c827-41f8-b917-02a056d76edd" />

After:
<img width="1514" height="1492" alt="image" src="https://github.com/user-attachments/assets/1f22ae25-fbdc-4ee1-8c32-dac58585e32e" />

Preview it at: https://mlir-python-googledocstring.surge.sh/autoapi/mlir/_mlir_libs/_mlir/ir/index.html

cc @makslevental @jpienaar 