### PR TITLE
Add PhoebeDB to MLIR Users

### DIFF
--- a/website/content/users/_index.md
+++ b/website/content/users/_index.md
@@ -267,6 +267,20 @@ filters, etc.) process packets.
 backend for the P4 reference compiler that uses MLIR, via new dialects to model P4's
 semantics.
 
+## [PhoebeDB](https://www.phoebedb.io/): A PostgreSQL-compatible HTAP database for AI agents
+
+PhoebeDB is a PostgreSQL-compatible HTAP database designed for production AI agent
+systems, in which relational state, vector memory, and execution traces commit (or
+roll back) together as a single atomic unit, with vector indexes participating in
+MVCC alongside relational data.
+
+PhoebeDB uses a custom MLIR pipeline to JIT-compile queries to native machine
+code, with progressive lowering through multiple dialects before reaching LLVM IR.
+This layered design keeps each lowering step narrow and auditable, making it
+easier to add new operators or backends without emitting LLVM IR directly.
+
+For more details, see the [MLIR JIT compilation deep-dive](https://www.phoebedb.io/blog/mlir-jit-compilation).
+
 ## [PlaidML](https://github.com/plaidml/plaidml)
 
 PlaidML is a tensor compiler that facilitates reusable and performance portable


### PR DESCRIPTION
This PR adds **PhoebeDB** to the MLIR users list.

[PhoebeDB](https://www.phoebedb.io/) is a PostgreSQL-compatible RDBMS kernel designed for production AI agent
systems. The PhoebeDB kernel was published at EDBT 2025, where it demonstrated significant transaction-processing improvements over PostgreSQL on TPC-C benchmarks.

PhoebeDB uses MLIR as the foundation of its SQL JIT compilation pipeline. Query plans are progressively lowered through multiple custom MLIR dialects before reaching LLVM IR and being compiled to native machine code.

This layered MLIR design keeps each lowering step narrow, structured, and auditable. It also makes it easier to add new operators, optimization passes, or backend targets without emitting LLVM IR directly from the query plan.

As PhoebeDB developers, we would like PhoebeDB to be listed as an MLIR user to make the project more visible to the community and to share our ongoing work on MLIR-based SQL JIT compilation.

References:

- PhoebeDB website: https://www.phoebedb.io/
- EDBT 2025 paper: https://www.openproceedings.org/2025/conf/edbt/paper-292.pdf
- MLIR JIT compilation in PhoebeDB: https://www.phoebedb.io/blog/mlir-jit-compilation