### PR TITLE
Developer guide: Improve section on IR verifiers

### DIFF
--- a/website/content/getting_started/DeveloperGuide.md
+++ b/website/content/getting_started/DeveloperGuide.md
@@ -98,6 +98,11 @@ single pass. Because the process is aborted when a verifier is failing, they
 must only fire on things that are definitive broken invariant, and not on
 "possibly invalid" cases.
 
+For details on the order in which the various verifiers attached to an
+operation are run (structural traits, ODS-generated `verifyInvariants`,
+trait/interface verifiers, custom verifier, region verifiers), see
+[Verification Ordering](/docs/DefiningDialects/Operations/#verification-ordering).
+
 ### Example: Undefined Behavior
 
 While it is encouraged to verify as much invariants as possible in order to
@@ -144,8 +149,8 @@ avoided.
 ### Structural Invariants
 
 Certain structural invariants of an operation are considered to be "local to
-the operation" and may be checked in the verifier. For examples here are common
-cases:
+the operation" and may be checked in the verifier. Here is a non-exhaustive
+list of examples:
 
 * Ops with regions may verify that a region has a certain number of blocks.
   Relevant op traits / constraints: `SingleBlock`, `SizedRegion`,

--- a/website/content/getting_started/DeveloperGuide.md
+++ b/website/content/getting_started/DeveloperGuide.md
@@ -143,22 +143,26 @@ avoided.
 
 ### Structural Invariants
 
-Structural invariants of an operation may be checked in the verifier, even
-though they may not be local to the operation.
+Certain structural invariants of an operation are considered to be "local to
+the operation" and may be checked in the verifier.
 
 * Ops with regions may verify that a region has a certain number of blocks.
   Relevant op traits / constraints: `SingleBlock`, `SizedRegion`,
   `MinSizedRegion`, `MaxSizedRegion`.
 * Ops with regions may verify that block terminators are of a certain op kind.
   Relevant op trait: `SingleBlockImplicitTerminator`.
+* Ops with regions may verify that operands that are yielded from terminators
+  have a compatible type. Relevant op interface method: `areTypesCompatible`.
+* Token users may verify that the token was produced by a compatible operation.
+
+Some structural invariants are not really "local to the operation" but are
+sometimes checked for composability reasons.
+
 * Ops may verify that they are nested within a supported op.
   Relevant op traits: `HasParent`, `ParentOneOf`, `HasAncestor`,
   `AncestorOneOf`.
 * Symbol tables and symbol users may verify the uniqueness and compatibility of
   of symbols. Relevant op interface method: `verifySymbolUses`.
-* Ops with regions may verify that operands that are yielded from terminators
-  have a compatible type. Relevant op interface method: `areTypesCompatible`.
-* Token users may verify that the token was produced by a compatible operation.
 
 ## Testing guidelines
 

--- a/website/content/getting_started/DeveloperGuide.md
+++ b/website/content/getting_started/DeveloperGuide.md
@@ -144,7 +144,8 @@ avoided.
 ### Structural Invariants
 
 Certain structural invariants of an operation are considered to be "local to
-the operation" and may be checked in the verifier.
+the operation" and may be checked in the verifier. For examples here are common
+cases:
 
 * Ops with regions may verify that a region has a certain number of blocks.
   Relevant op traits / constraints: `SingleBlock`, `SizedRegion`,

--- a/website/content/getting_started/DeveloperGuide.md
+++ b/website/content/getting_started/DeveloperGuide.md
@@ -98,6 +98,8 @@ single pass. Because the process is aborted when a verifier is failing, they
 must only fire on things that are definitive broken invariant, and not on
 "possibly invalid" cases.
 
+### Example: Undefined Behavior
+
 While it is encouraged to verify as much invariants as possible in order to
 catch bugs during development as soon as possible, there is some important
 aspect to keep in mind. In particular a common point of confusion is about how
@@ -138,6 +140,25 @@ This is why the guidelines to write verifier is to stick to information local
 to an operation (think "what I see when I print this operation alone").
 Looking through operands or results is extremely unusual and should be
 avoided.
+
+### Structural Invariants
+
+Structural invariants of an operation may be checked in the verifier, even
+though they may not be local to the operation.
+
+* Ops with regions may verify that a region has a certain number of blocks.
+  Relevant op traits / constraints: `SingleBlock`, `SizedRegion`,
+  `MinSizedRegion`, `MaxSizedRegion`.
+* Ops with regions may verify that block terminators are of a certain op kind.
+  Relevant op trait: `SingleBlockImplicitTerminator`.
+* Ops may verify that they are nested within a supported op.
+  Relevant op traits: `HasParent`, `ParentOneOf`, `HasAncestor`,
+  `AncestorOneOf`.
+* Symbol tables and symbol users may verify the uniqueness and compatibility of
+  of symbols. Relevant op interface method: `verifySymbolUses`.
+* Ops with regions may verify that operands that are yielded from terminators
+  have a compatible type. Relevant op interface method: `areTypesCompatible`.
+* Token users may verify that the token was produced by a compatible operation.
 
 ## Testing guidelines
 


### PR DESCRIPTION
Describe that certain structural invariants may be checked by the IR verifier.

Also explicitly mention tokens. Verifiers may check that a token was produced by a certain operation.

RFC: https://discourse.llvm.org/t/rfc-add-a-builtin-token-type-to-mlir/90706
