### PR TITLE
Fix namespace handling in MLIR Python API docs

### DIFF
--- a/sphinx-mlir-python/conf.py
+++ b/sphinx-mlir-python/conf.py
@@ -31,10 +31,64 @@ html_static_path = ['_static']
 # https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html
 
 import os
+from pathlib import Path
+import shutil
+
 import mlir
 
-autoapi_dirs = list(mlir.__path__)
-autoapi_python_use_implicit_namespaces = True
+
+def stage_autoapi_input(package_paths):
+    """Create a docs-only regular-package view of the MLIR namespace.
+
+    AutoAPI discovers modules inside implicit namespaces, but it does not
+    create objects for namespace package directories. Astroid can also lose
+    the leading ``mlir`` component while resolving imports such as
+    ``from ._mlir_libs...`` from the namespace root. Mirror only the Python
+    inputs and add package markers in the build directory so both tools see a
+    complete hierarchy without changing the real MLIR package.
+    """
+    stage_root = Path(__file__).resolve().parent / "_build" / "autoapi-input"
+    if stage_root.exists():
+        shutil.rmtree(stage_root)
+
+    staged_mlir = stage_root / "mlir"
+    package_dirs = {staged_mlir}
+    for package_path in package_paths:
+        source_root = Path(package_path)
+        for source_path in sorted(source_root.rglob("*")):
+            if (
+                source_path.suffix not in {".py", ".pyi"}
+                or not source_path.is_file()
+            ):
+                continue
+
+            destination = staged_mlir / source_path.relative_to(source_root)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            if not destination.exists():
+                shutil.copy2(source_path, destination)
+
+            parent = destination.parent
+            while True:
+                package_dirs.add(parent)
+                if parent == staged_mlir:
+                    break
+                parent = parent.parent
+
+    for package_dir in package_dirs:
+        if not (package_dir / "__init__.py").exists() and not (
+            package_dir / "__init__.pyi"
+        ).exists():
+            (package_dir / "__init__.py").touch()
+
+    return staged_mlir
+
+
+autoapi_dirs = [str(stage_autoapi_input(mlir.__path__))]
+autoapi_python_use_implicit_namespaces = False
+
+# index.rst already links directly to autoapi/mlir/index. Avoid generating an
+# unused autoapi/index page as well.
+autoapi_add_toctree_entry = False
 
 import autoapi._parser as _autoapi_parser
 import autoapi._mapper as _autoapi_mapper
@@ -94,15 +148,3 @@ if llvm_path := os.environ.get("SPHINX_LLVM_SRC_PATH"):
     lexer_spec.loader.exec_module(lexer_module)
 
     _hl.lexers["mlir"] = lexer_module.MlirLexer()
-
-# generate an index page for the mlir namespace
-def ensure_mlir_index(_):
-    mlir_dir = os.path.join(os.path.dirname(__file__), "autoapi/mlir")
-    os.makedirs(mlir_dir, exist_ok=True)
-    mlir_index = os.path.join(mlir_dir, "index.rst")
-    with open(mlir_index, "w", encoding="utf-8") as f:
-        f.write("mlir namespace\n===============\n\n.. toctree::\n   :maxdepth: 2\n   :glob:\n\n   **\n")
-
-
-def setup(app):
-    app.connect("builder-inited", ensure_mlir_index)


### PR DESCRIPTION
MLIR Python uses implicit namespace packages, but AutoAPI does not create namespace objects for those directories. The existing glob-based workaround flattens and duplicates the navigation, while imports from `_mlir_libs` are resolved incorrectly and public modules such as `mlir.ir`, `mlir.passmanager`, and `mlir.rewrite` omit APIs supplied by the native core stubs.

This creates a documentation-only regular-package view of the Python sources so AutoAPI can build the actual module hierarchy and resolve the core re-exports, then removes the globbed namespace index.

## Before:

<!-- screenshot -->

<img width="1799" height="1214" alt="image" src="https://github.com/user-attachments/assets/efc40115-57ac-4c27-b394-2344daa31252" />

<img width="1850" height="1210" alt="image" src="https://github.com/user-attachments/assets/2df12db5-bbc2-4352-a197-1020c42d9185" />


## After:

<!-- screenshot -->

<img width="1801" height="1013" alt="image" src="https://github.com/user-attachments/assets/dd671818-fe0a-4246-911e-ae8c06684470" />

<img width="1783" height="1196" alt="image" src="https://github.com/user-attachments/assets/fb959340-b9e5-485e-a058-a63bc24d3ed9" />


Assisted by: Codex / GPT 5.6 Sol