### PR TITLE
Refresh and expand the MLIR users page

### DIFF
--- a/website/content/users/_index.md
+++ b/website/content/users/_index.md
@@ -1,390 +1,350 @@
 ---
 title: "Users of MLIR"
-date: 2023-05-04T21:00:54Z
+date: 2023-05-04
+lastmod: 2026-09-02
 draft: false
 weight: 1
 ---
 
-In alphabetical order below.
+This page collects publicly documented projects that use MLIR as compiler
+infrastructure or define MLIR dialects and transformations. Entries are
+alphabetized by project name. Archived or superseded projects are labeled.
+
+Know of a project that is missing, or one whose description has changed? Please
+submit an update to this page.
 
 ## [Accera](https://github.com/microsoft/Accera)
 
-Accera is a compiler that enables you to experiment with loop optimizations without
-hand-writing Assembly code. With Accera, these problems and impediments can be
-addressed in an optimized way. It is available as a Python library and supports
-cross-compiling to a wide range of processor targets.
+Accera is a research compiler and Python library from Microsoft Research for
+scheduling compute-intensive loop nests. It translates programs through MLIR
+pipelines to produce optimized binaries for target platforms.
 
 ## [Allo](https://github.com/cornell-zhang/allo)
 
-Allo is a Python-embedded Accelerator Design Language (ADL) and compiler that
-facilitates the construction of large-scale, high-performance hardware accelerators
-in a modular and composable manner. It supports progressive hardware customizations,
-reusable parameterized kernel templates, and composable schedules on top of MLIR
-for productive hardware development.
+Allo is a Python-embedded language and compiler for accelerator design. It uses
+MLIR to represent modular kernels, compose schedules, and lower designs to
+hardware and software backends.
 
-## [AscendNPU IR](https://gitcode.com/Ascend/AscendNPU-IR)
+## [AscendNPU IR](https://gitee.com/ascend/ascendnpu-ir)
 
-AscendNPU IR is an MLIR-based intermediate representation and compiler framework
-specifically designed for Ascend hardware. It enables the efficient execution of
-computational workloads on the Ascend NPU by applying a rich set of compiler
-optimizations that fully leverage the hardware's capabilities.
+AscendNPU IR is an MLIR-based intermediate-representation system for Huawei
+Ascend NPUs. It provides dialects, transformations, and interfaces for
+describing and optimizing AI workloads.
 
 ## [Beaver](https://github.com/beaver-lodge/beaver)
 
-Beaver is an MLIR frontend in Elixir and Zig.
-Powered by Elixir's composable modularity and meta-programming features,
-Beaver provides a simple, intuitive, and extensible interface for MLIR.
+Beaver provides MLIR and LLVM tooling for Elixir and Zig. It uses Elixir's
+metaprogramming facilities to make defining and manipulating MLIR dialects and
+operations more accessible.
 
-## [Bᴛᴏʀ2ᴍʟɪʀ](https://github.com/jetafese/btor2mlir): A Format and Toolchain for Hardware Verification
+## [BTOR2MLIR](https://github.com/jetafese/btor2mlir)
 
-Bᴛᴏʀ2ᴍʟɪʀ applies MLIR to the domain of hardware verification by offering a clean way to take advantage of a format's
-strengths. For example, we support the use of software verification methods for hardware
-verification problems represented in the Bᴛᴏʀ2 format. The project aims to spur and support research
-in the formal verification domain, and has been shown to be competitive with existing methods.
+BTOR2MLIR is an MLIR dialect and toolchain for the BTOR2 hardware-verification
+format. It enables BTOR2 models to reuse compiler transformations and software
+verification backends.
+
+## [Buddy MLIR](https://github.com/buddy-compiler/buddy-mlir)
+
+Buddy MLIR is a compiler framework that connects domain-specific languages to
+domain-specific architectures. It provides MLIR dialects, transformations,
+runtime components, and examples for heterogeneous systems.
+
+## [ByteIR](https://github.com/bytedance/byteir)
+
+ByteIR is an MLIR-based compiler for CPUs, GPUs, and ASICs. It provides compiler
+passes, frontends, and runtime components for lowering machine-learning
+workloads across heterogeneous targets.
 
 ## [Catalyst](https://github.com/PennyLaneAI/catalyst)
 
-Catalyst is an AOT/JIT compiler for [PennyLane](https://pennylane.ai/) that
-accelerates hybrid quantum programs, with:
+Catalyst is an experimental just-in-time compiler for hybrid
+quantum-classical PennyLane programs. Its MLIR-based compiler represents
+quantum operations in dedicated dialects and lowers programs through LLVM and
+QIR while supporting control flow and automatic differentiation.
 
-- full auto-differentiation support, via custom quantum gradients
-  and [Enzyme](https://github.com/EnzymeAD/Enzyme)-based backpropagation,
-- a dynamic quantum programming model,
-- and integration into the Python ML ecosytem.
+## [CIRCT](https://circt.llvm.org/)
 
-Catalyst also comes with the [Lightning](https://github.com/PennyLaneAI/pennylane-lightning/)
-high performance simulator by default, but supports an extensible backend system that is
-constantly evolving, aiming to deliver execution on heterogenous architectures with GPUs and QPUs.
+CIRCT is an application of MLIR and LLVM methodology to hardware
+design. It provides reusable dialects, transformations, and tools for hardware
+compilers and electronic-design-automation workflows.
 
-## [CIRCT](https://github.com/llvm/circt): Circuit IR Compilers and Tools
+## [ClangIR](https://clang.llvm.org/docs/CIR/)
 
-The CIRCT project is an (experimental!) effort looking to apply MLIR and the LLVM
-development methodology to the domain of hardware design tools.
+ClangIR (CIR) introduces a high-level MLIR representation between Clang's AST
+and LLVM IR. It preserves more C and C++ semantics for analysis and
+transformation before lowering to LLVM IR.
 
-## [ClangIR](https://llvm.github.io/clangir/)
+## [Concrete](https://github.com/zama-ai/concrete)
 
-ClangIR is a high-level representation in Clang that reflects aspects of the
-C/C++ languages and their extensions. It is implemented using MLIR and occupies
-a position between Clang’s AST and LLVM IR.
+Concrete is an open-source compiler for programs that operate on
+fully-homomorphic-encryption data. Its Python interface lowers encrypted
+programs through MLIR and LLVM to implementations based on TFHE.
 
-## [Concrete](https://github.com/zama-ai/concrete): TFHE Compiler that converts python programs into FHE equivalent
+## [CUDA-Q](https://github.com/NVIDIA/cuda-quantum)
 
-Concrete is an open-source framework that simplifies the use of
-[Fully Homomorphic Encryption](https://fhe.org) (FHE) and makes writing FHE
-programs easy for developers
+CUDA-Q is a heterogeneous quantum-classical programming platform. Its compiler
+uses MLIR dialects for quantum and classical computation before lowering to
+QIR, LLVM IR, or target-specific representations.
 
-FHE is a powerful technology that enables computations on encrypted data without
-needing to decrypt it. This capability ensures user privacy and provides robust
-protection against data breaches.
+## [DSP-MLIR](https://github.com/MPSLab-ASU/DSP_MLIR)
 
-Concrete enables developers to efficiently develop privacy-preserving
-applications for various use cases. For instance,
-[Concrete ML](https://github.com/zama-ai/concrete-ml) is built on top of
-Concrete to integrate privacy-preserving features of FHE into machine learning
-use cases.
+DSP-MLIR is an experimental MLIR dialect and compiler for digital signal
+processing. It represents common DSP operations and applies domain-specific
+rewrites before lowering them through MLIR.
 
-## [DSP-MLIR](https://github.com/MPSLab-ASU/DSP_MLIR): A Framework for Digital Signal Processing Applications in MLIR
+## [Enzyme](https://enzyme.mit.edu/)
 
-DSP-MLIR is a framework designed specifically for DSP applications. It provides
-a DSL (Frontend), compiler, and rewrite patterns that detect DSP patterns and
-apply optimizations based on DSP theorems. The framework supports a wide range
-of DSP operations, including filters (FIR, IIR, filter response), transforms
-(DCT, FFT, IFFT), and other signal processing operations such as delay and gain,
-along with additional functionalities for application development. 
+Enzyme provides automatic differentiation across multiple compiler levels.
+[EnzymeMLIR](https://github.com/EnzymeAD/Enzyme/tree/main/enzyme/Enzyme/MLIR)
+exposes first-class forward- and reverse-mode differentiation in MLIR. Projects
+such as
+[Enzyme-JAX](https://github.com/EnzymeAD/Enzyme-JAX) use it in MLIR-based
+compiler pipelines.
 
-## [Enzyme](https://enzyme.mit.edu): General Automatic Differentiation of MLIR
-Enzyme (specifically EnzymeMLIR) is a first-class automatic differentiation 
-sytem for MLIR. Operations and types implement or inheret general interfaces
-to specify their differentiable behavior, which allows Enzyme to provide
-efficient forward and reverse pass derivatives. Source code is available [here](https://github.com/EnzymeAD/Enzyme/tree/main/enzyme/Enzyme/MLIR).
-See also the [Enzyme-JaX](https://github.com/EnzymeAD/Enzyme-JAX) project which
-uses Enzyme to differentiate StableHLO, and thus provide MLIR-native
-differentiation and codegen for JaX.
+## [EUDSL](https://github.com/llvm/eudsl)
 
-## [Firefly](https://github.com/GetFirefly/firefly): A new compiler and runtime for BEAM languages
+EUDSL is an experimental LLVM project for building embedded domain-specific
+languages that target MLIR. It includes language bindings, code generators,
+and utilities for constructing MLIR-based frontends and tools.
 
-Firefly is not only a compiler, but a runtime as well. It consists of two parts:
+## [Firefly](https://github.com/GetFirefly/firefly) (archived)
 
-- A compiler for Erlang to native code for a given target (x86, ARM, WebAssembly)
-- An Erlang runtime, implemented in Rust, which provides the core functionality
-  needed to implement OTP
+Firefly was a compiler and runtime for Erlang and Elixir. It used MLIR for its
+final optimization and code-generation stages, targeting native code and
+WebAssembly. The project was archived in June 2024.
 
-The primary motivator for Firefly's development was the ability to compile Elixir
-applications that could target WebAssembly, enabling use of Elixir as a language
-for frontend development. It is also possible to use Firefly to target other
-platforms as well, by producing self-contained executables on platforms such as
-x86.
+## [Flang](https://flang.llvm.org/docs/)
 
-## [Flang](https://github.com/llvm/llvm-project/tree/main/flang)
+Flang is LLVM's Fortran frontend. Its FIR and HLFIR dialects use MLIR to
+represent, analyze, optimize, and lower Fortran programs before LLVM code
+generation.
 
-Flang is a ground-up implementation of a Fortran front end written in modern C++.
-It started off as the [f18 project](https://github.com/flang-compiler/f18) with an
-aim to replace the previous [flang project](https://github.com/flang-compiler/flang)
-and address its various deficiencies. F18 was subsequently accepted into the LLVM
-project and rechristened as Flang. The high level IR of the Fortran compiler is modeled
-using MLIR.
+## [HEIR](https://heir.dev/)
 
-## [HEIR](https://github.com/google/heir)
+HEIR is an open-source MLIR toolchain for homomorphic encryption. It defines
+dialects and transformations spanning high-level tensor programs,
+encryption-scheme representations, and target cryptographic libraries.
 
-HEIR (Homomorphic Encryption Intermediate Representation) is an MLIR-based
-toolchain developed by Google for compiling programs that utilize homomorphic
-encryption. Homomorphic encryption allows computations to be performed directly
-on encrypted data without needing to decrypt it first, thereby preserving data
-privacy throughout the computational process.
+## [Hexagon-MLIR](https://github.com/qualcomm/hexagon-mlir)
 
-Building upon the foundation of MLIR (Multi-Level Intermediate Representation),
-HEIR provides a flexible and extensible framework for developing compilers
-targeting homomorphic encryption. This approach facilitates the optimization and
-transformation of code in a manner that is both modular and scalable.
+Hexagon-MLIR is an open-source compiler stack for Qualcomm Hexagon NPUs. It
+uses MLIR to lower Triton kernels and PyTorch models through Hexagon-specific
+dialects, transformations, and runtime interfaces.
 
-## [IREE](https://github.com/google/iree)
+## [Intel Extension for MLIR (IMEX)](https://github.com/intel/mlir-extensions)
 
-IREE (pronounced "eerie") is a compiler and minimal runtime system for
-compiling ML models for execution against a HAL (Hardware Abstraction Layer)
-that is aligned with Vulkan. It aims to be a viable way to compile and run
-ML devices on a variety of small and medium sized systems, leveraging either
-the GPU (via Vulkan/SPIR-V), CPU or some combination. It also aims to
-interoperate seamlessly with existing users of Vulkan APIs, specifically
-focused on games and rendering pipelines.
+IMEX develops MLIR dialects, transformations, and runtime integrations for
+Intel CPUs and GPUs. It also serves as a staging ground for components intended
+for upstream MLIR.
+
+## [IREE](https://github.com/iree-org/iree)
+
+IREE is an end-to-end MLIR-based compiler and runtime for machine-learning
+models. Its retargetable stack scales from data-center systems to mobile and
+edge devices across a range of accelerator backends.
 
 ## [JSIR](https://github.com/google/jsir)
 
-JSIR is a next-generation JavaScript analysis tool. At its core is an MLIR-based
-high-level intermediate representation, which supports both dataflow analysis
-and lossless conversion back to source. This unique design makes it suitable for
-source-to-source transformation. JSIR is used at Google for analyzing and
-detecting malicious JavaScript files, protecting products like Ads, Android, and
-Chrome.
+JSIR is an MLIR-based high-level representation for JavaScript analysis and
+lossless source-to-source transformation. Google uses it for tasks including
+decompilation and deobfuscation.
 
-## [Kokkos](https://kokkos.org)
+## [LAPIS](https://github.com/sandialabs/LAPIS)
 
-The Kokkos C++ Performance Portability Ecosystem is a production level solution 
-for writing modern C++ applications in a hardware agnostic way. It is part of the 
-US Department of Energies Exascale Project – the leading effort in the US to prepare 
-the HPC community for the next generation of super computing platforms. The Ecosystem 
-consists of multiple libraries addressing the primary concerns for developing and 
-maintaining applications in a portable way. The three main components are the Kokkos 
-Core Programming Model, the Kokkos Kernels Math Libraries and the Kokkos Profiling and 
-Debugging Tools.
+LAPIS is an MLIR-based compiler for linear-algebra workloads that targets
+Kokkos and other performance-portability programming models. It can integrate
+with Torch-MLIR to compile models originating in PyTorch.
 
-There is current [work](https://github.com/kokkos/kokkos.github.io/files/13651039/Kokkos_MLIR.pdf) 
-ongoing to convert MLIR to portable Kokkos-based source code, add a partition dialect 
-to MLIR to support tiled and distributed sparse tensors and target spatial dataflow 
+## [LingoDB](https://github.com/lingo-db/lingo-db)
+
+LingoDB is an MLIR-based query compiler for relational and other data-intensive
+workloads. It uses multiple dialects and transformation stages to optimize and
+JIT-compile database queries.
+
+## [MARCO](https://github.com/marco-compiler/marco)
+
+MARCO is an experimental Modelica compiler. It represents Base Modelica
+programs with an MLIR dialect and lowers them to executable code and supporting
+runtime components.
+
+## [MLIR-AIE (IRON)](https://github.com/Xilinx/mlir-aie)
+
+MLIR-AIE provides an MLIR toolchain and the IRON Python API for AMD Ryzen AI
+NPUs and Versal AI Engines. It models compute tiles, data movement, and device
+configuration and lowers programs to deployable device artifacts.
+
+## [MLIR-AIR](https://github.com/Xilinx/mlir-air)
+
+MLIR-AIR provides dialects, tools, and libraries for asynchronous,
+hierarchical accelerator programming. It models data movement and execution on
+spatial accelerators and integrates with MLIR-AIE for AMD AI Engine targets.
+
+## [MLIR-DaCe](https://github.com/spcl/mlir-dace)
+
+MLIR-DaCe connects MLIR with DaCe's Stateful DataFlow Graph representation. Its
+data-centric dialect and conversion infrastructure enable optimization across
+the two ecosystems.
+
+## [MLIR-EmitC](https://github.com/iml130/mlir-emitc) (archived and superseded)
+
+MLIR-EmitC developed conversions from MLIR dialects to C and C++. The project
+was archived in December 2024 and superseded by the upstream
+[EmitC dialect and emitter](https://mlir.llvm.org/docs/Dialects/EmitC/).
+
+## [MLIR-TensorRT](https://github.com/NVIDIA/TensorRT-Incubator/tree/main/mlir-tensorrt)
+
+MLIR-TensorRT is a compiler and runtime for executing MLIR programs with
+TensorRT and GPU code-generation backends. It accepts StableHLO and other MLIR
+dialects, partitions supported work for TensorRT, and lowers remaining
+operations through fallback pipelines.
+
+## [Mojo](https://mojolang.org/)
+
+Mojo is an open-source, Pythonic systems programming language for
+high-performance heterogeneous computing. Its compiler is built with MLIR and
+supports interoperability with the Python ecosystem.
+
+## [MQT Compiler Collection](https://github.com/munich-quantum-toolkit/core)
+
+The MQT Compiler Collection is an MLIR-based framework in MQT Core for quantum
+and classical compilation. It provides quantum dialects, transformations, and
+interoperability with formats and tools across the quantum software ecosystem.
+
+## [Numba-MLIR](https://github.com/numba/numba-mlir)
+
+Numba-MLIR is a proof-of-concept Numba backend that uses MLIR for CPU and GPU
+code generation. It retains Numba-compatible Python decorators and frontend
+behavior while replacing the downstream compiler pipeline.
+
+## [ONNX-MLIR](https://onnx.ai/onnx-mlir/)
+
+ONNX-MLIR imports ONNX models into MLIR and lowers them to optimized native
+binaries or libraries. Its dialects and passes support targets ranging from
+general-purpose processors to specialized accelerators.
+
+## [OpenXLA](https://openxla.org/)
+
+OpenXLA is an open machine-learning compiler ecosystem whose projects include
+XLA, StableHLO, and Shardy. These projects use MLIR to represent and transform
+models from frameworks such as JAX, TensorFlow, and PyTorch for CPUs, GPUs, and
 accelerators.
 
-## [Lingo DB](https://www.lingo-db.com): Revolutionizing Data Processing with Compiler Technology
+## [PhoebeDB](https://phoebedb.com/)
 
-LingoDB is a cutting-edge data processing system that leverages compiler technology
-to achieve unprecedented flexibility and extensibility without sacrificing
-performance. It supports a wide range of data-processing workflows beyond
-relational SQL queries, thanks to declarative sub-operators. Furthermore,
-LingoDB can perform cross-domain optimization by interleaving optimization
-passes of different domains and its flexibility enables sustainable support
-for heterogeneous hardware.
+PhoebeDB is a PostgreSQL-compatible HTAP database system. Its query compiler
+uses a custom MLIR pipeline to optimize relational operations and JIT-compile
+them through LLVM.
 
-LingoDB heavily builds on the MLIR compiler framework for compiling queries
-to efficient machine code without much latency.
+## [PlaidML](https://github.com/plaidml/plaidml) (archived)
 
-## [MARCO](https://github.com/marco-compiler/marco): Modelica Advanced Research COmpiler
-MARCO is a prototype compiler for the Modelica language, with focus on the
-efficient compilation and simulation of large-scale models.
-The Modelica source code is processed by external tools to obtain a
-modeling language independent representation in Base Modelica, for which an
-MLIR dialect has been designed.
+PlaidML was a portable tensor compiler and runtime. Its experimental v1
+architecture adopted MLIR for graph and kernel compilation. The project was
+archived in March 2025.
 
-The project is complemented by multiple runtime libraries, written in C++, that
-are used to drive the generated simulation, provide support functions, and to
-ease interfacing with external differential equations solvers.
+## [PolyBlocks](https://docs.polymagelabs.com/)
 
-## [MLIR-AIE](https://github.com/Xilinx/mlir-aie): Toolchain for AMD/Xilinx AIEngine devices
+PolyBlocks is a commercial MLIR-based JIT and ahead-of-time compilation engine
+for machine learning. It supports models from PyTorch, TensorFlow, and JAX and
+targets CPUs and multiple accelerator platforms.
 
-MLIR-AIE is a toolchain providing low-level device configuration for Versal
-AIEngine-based devices. Support is provided to target the AIEngine portion of
-the device, including processors, stream switches, TileDMA and ShimDMA blocks.
-Backend code generation is included, targetting the LibXAIE library, along with
-some higher-level abstractions enabling higher-level design.
+## [Polygeist](https://github.com/llvm/Polygeist)
 
-## [MLIR-DaCe](https://github.com/spcl/mlir-dace): Data-Centric MLIR Dialect
+Polygeist is a C and C++ frontend for MLIR. It preserves high-level control
+flow, memory, and parallel constructs so they can be analyzed and transformed
+before lowering to lower-level dialects.
 
-MLIR-DaCe is a project aiming to bridge the gap between control-centric and
-data-centric intermediate representations. By bridging these two groups of IRs,
-it allows the combination of control-centric and data-centric optimizations in
-optimization pipelines. In order to achieve this, MLIR-DaCe provides a data-centric
-dialect in MLIR to connect the MLIR and DaCe frameworks.
+## [PyDSL](https://github.com/Huawei-CPLLab/PyDSL)
 
-## [MLIR-EmitC](https://github.com/iml130/mlir-emitc)
+PyDSL is a Pythonic frontend for MLIR. It maps a deliberately close-to-Python
+syntax to MLIR operations, types, and control flow while keeping the translation
+layer thin and extensible.
 
-MLIR-EmitC provides a way to translate ML models into C++ code. The repository
-contains scripts and tools to translate Keras and TensorFlow models into the
-[TOSA](https://mlir.llvm.org/docs/Dialects/TOSA/) and
-[StableHLO](https://github.com/openxla/stablehlo/) dialect and to convert those to
-[EmitC](https://mlir.llvm.org/docs/Dialects/EmitC/).
-The latter is used to generate calls to a reference implementation.
+## [Pylir](https://github.com/Pylir/Pylir)
 
-The [EmitC](https://mlir.llvm.org/docs/Dialects/EmitC/) dialect itself, as well
-as the C++ emitter, are part of MLIR core and are no longer provided as part of
-the MLIR-EmitC repository.
+Pylir is an optimizing ahead-of-time compiler for Python. It represents Python
+semantics in custom high-level MLIR dialects and progressively lowers programs
+to LLVM IR.
 
-## [Mojo](https://docs.modular.com/mojo/)
+## [Qwerty](https://github.com/gt-tinker/qwerty)
 
-Mojo is a new programming language that bridges the gap between research and
-production by combining the best of Python syntax with systems programming and
-metaprogramming, all leveraging the MLIR ecosystem.
-It aims to be a strict superset of Python (i.e. be compatible with existing
-programs) and to embrace the CPython immediately for long-tail ecosystem
-enablement.
-
-## [Nod Distributed Runtime](https://nod.ai/project/distributedruntime/): Asynchronous fine-grained op-level parallel runtime
-
-Nod's MLIR based Parallel Compiler and Distributed Runtime  provide a way to
-easily scale out training and inference of very large models across multiple
-heterogeneous devices (CPUs/GPUs/Accelerators/FPGAs)  in a cluster while
-exploiting fine-grained op-level parallelism.
-
-## [ONNX-MLIR](https://github.com/onnx/onnx-mlir)
-
-To represent neural network models, users often use [Open Neural Network
-Exchange (ONNX)](http://onnx.ai/onnx-mlir/) which is an open standard format for
-machine learning interoperability.
-ONNX-MLIR is a MLIR-based compiler for rewriting a model in ONNX into a standalone
-binary that is executable on different target hardwares such as x86 machines,
-IBM Power Systems, and IBM System Z.
-
-See also this paper: [Compiling ONNX Neural Network Models Using
-MLIR](https://arxiv.org/abs/2008.08272).
-
-## [OpenXLA](https://github.com/openxla)
-
-A community-driven, open source ML compiler ecosystem, using the best of XLA & MLIR.
-
-## [P4](https://p4.org/)
-
-Programming Protocol-independent Packet Processors (P4) is a domain-specific language
-for network devices, specifying how data plane devices (switches, NICs, routers,
-filters, etc.) process packets.
-
-[P4HIR](https://github.com/p4lang/project-ideas/issues/20) is a project to create a
-backend for the P4 reference compiler that uses MLIR, via new dialects to model P4's
-semantics.
-
-## [PhoebeDB](https://www.phoebedb.io/): A PostgreSQL-compatible HTAP database for AI agents
-
-PhoebeDB is a PostgreSQL-compatible HTAP database designed for production AI agent
-systems, in which relational state, vector memory, and execution traces commit (or
-roll back) together as a single atomic unit, with vector indexes participating in
-MVCC alongside relational data.
-
-PhoebeDB uses a custom MLIR pipeline to JIT-compile queries to native machine
-code, with progressive lowering through multiple dialects before reaching LLVM IR.
-This layered design keeps each lowering step narrow and auditable, making it
-easier to add new operators or backends without emitting LLVM IR directly.
-
-For more details, see the [MLIR JIT compilation deep-dive](https://www.phoebedb.io/blog/mlir-jit-compilation).
-
-## [PlaidML](https://github.com/plaidml/plaidml)
-
-PlaidML is a tensor compiler that facilitates reusable and performance portable
-ML models across various hardware targets including CPUs, GPUs, and
-accelerators.
-
-## [PolyBlocks](https://www.polymagelabs.com/technology/#polyblocks): An MLIR-based JIT and AOT compiler
-
-PolyBlocks is a high-performance MLIR-based end-to-end compiler for DL and
-non-DL computations. It can perform both JIT and AOT compilation. Its compiler
-engine is aimed at being fully automatic, modular, analytical model-driven, and
-fully code generating (no reliance on vendor/HPC libraries).
-
-## [Polygeist](https://github.com/llvm/Polygeist): C/C++ frontend and optimizations for MLIR
-
-Polygeist is a C/C++ frontend for MLIR which preserves high-level structure
-from programs such as parallelism. Polygeist also includes high-level optimizations
-for MLIR, as well as various raising/lowering utilities.
-
-See both the polyhedral Polygeist paper
-[Polygeist: Raising C to Polyhedral MLIR](https://ieeexplore.ieee.org/document/9563011)
-and the GPU Polygeist paper
-[High-Performance GPU-to-CPU Transpilation and Optimization via High-Level Parallel Constructs](https://arxiv.org/abs/2207.00257)
-
-## [PyDSL](https://github.com/Huawei-CPLLab/PyDSL): A pythonic frontend for MLIR
-
-PyDSL aims to provide an interface between Python and MLIR. 
-The project aims for simplicity, i.e., the project should be easy to maintain with a 
-thin layer of translation, as well as that the syntax for PyDSL should be as close 
-to legal Python as possible, while maintaining the precision of MLIR.
-
-## [Pylir](https://github.com/zero9178/Pylir)
-
-Pylir aims to be an optimizing Ahead-of-Time Python Compiler with high language
-conformance. It uses MLIR Dialects for the task of high level, language specific
-optimizations as well as LLVM for code generation and garbage collector
-support.
+Qwerty is a compiler and runtime for a Python-embedded,
+basis-oriented quantum programming language. It uses MLIR for its high-level
+quantum representation and can emit OpenQASM 3 and QIR.
 
 ## [RISE](https://rise-lang.org/)
 
-RISE is a spiritual successor to the
-[Lift project](http://www.lift-project.org/): "a high-level functional data
-parallel language with a system of rewrite rules which encode algorithmic
-and hardware-specific optimisation choices".
+RISE is a functional language for expressing and optimizing parallel
+computations. Its research MLIR integration represents RISE programs as a
+dialect and lowers optimized computations toward C, OpenMP, OpenCL, and CUDA.
 
-## [SOPHGO TPU-MLIR](https://github.com/sophgo/tpu-mlir)
+## [rocMLIR](https://github.com/ROCm/rocMLIR)
 
-TPU-MLIR is an open-source machine-learning compiler based on MLIR for
-SOPHGO TPU. https://arxiv.org/abs/2210.15016.
+rocMLIR is an MLIR-based kernel generator for AMD GPUs. It specializes and
+lowers operations such as matrix multiplication, convolution, and attention
+and is used by projects including MIGraphX.
 
-## [Substrait MLIR](https://github.com/substrait-io/substrait-mlir-contrib/)
+## [ScaleHLS](https://github.com/UIUC-ChenLab/scalehls)
 
-Substrait MLIR is an input/output dialect for
-[Substrait](https://substrait.io/), the cross-language serialization format of
-database query plans (akin to an intermediate representation/IR for database
-queries).
+ScaleHLS is an MLIR-based high-level-synthesis framework. It compiles HLS C/C++
+or PyTorch models through domain-specific analyses and optimizations and emits
+optimized HLS C/C++ for FPGA toolchains.
+
+## [Substrait MLIR](https://github.com/substrait-io/substrait-mlir-contrib)
+
+Substrait MLIR is a work-in-progress dialect and serialization library for the
+Substrait query-plan format. It provides common infrastructure for projects
+that need to import, transform, or export Substrait plans with MLIR.
 
 ## [TensorFlow](https://www.tensorflow.org/mlir)
 
-MLIR is used as a Graph Transformation framework and the foundation for
-building many tools (XLA, TFLite converter, quantization, ...).
+TensorFlow uses MLIR across its compiler stack to represent, transform, and
+lower machine-learning programs. MLIR-based infrastructure supports graph
+optimization, hardware targeting, and deployment-oriented compilation.
 
-## [Tenstorrent MLIR Compiler](https://github.com/tenstorrent/tt-mlir)
+## [Tenstorrent tt-mlir](https://github.com/tenstorrent/tt-mlir)
 
-tt-mlir is a compiler project aimed at defining MLIR dialects to abstract compute
-on Tenstorrent AI accelerators. It is built on top of the MLIR compiler infrastructure
-and targets TTNN.
+tt-mlir is Tenstorrent's MLIR compiler stack. It defines dialects and lowering
+pipelines that transform machine-learning workloads for Tenstorrent hardware
+and its TTNN and TT-Metal software layers.
 
-For more information on the project, see https://tenstorrent.github.io/tt-mlir/.
+## [TFRT](https://github.com/tensorflow/runtime)
 
-## [TFRT: TensorFlow Runtime](https://github.com/tensorflow/runtime)
-
-TFRT aims to provide a unified, extensible infrastructure layer for an
-asynchronous runtime system.
+TFRT provides asynchronous host-runtime and compiler infrastructure used in
+TensorFlow and XLA execution paths. Its MLIR components represent host programs
+and lower them to executable runtime forms.
 
 ## [Torch-MLIR](https://github.com/llvm/torch-mlir)
 
-The Torch-MLIR project aims to provide first class compiler support from the
-PyTorch ecosystem to the MLIR ecosystem.
+Torch-MLIR imports PyTorch programs into MLIR's Torch dialect. It then lowers
+them into representations that can be consumed by the wider MLIR compiler
+ecosystem and target-specific backends.
 
-## [Triton](https://github.com/openai/triton)
+## [TPP-MLIR](https://github.com/libxsmm/tpp-mlir)
 
-Triton is a language and compiler for writing highly efficient custom
-Deep-Learning primitives. The aim of Triton is to provide an open-source
-environment to write fast code at higher productivity than CUDA, but also
-with higher flexibility than other existing DSLs.
+TPP-MLIR provides an MLIR dialect and compilation flow for Tensor Processing
+Primitives. It lowers linear-algebra workloads to optimized primitive libraries
+such as LIBXSMM.
 
-## [VAST](https://github.com/trailofbits/vast): C/C++ frontend for MLIR
+## [TPU-MLIR (SOPHGO)](https://github.com/sophgo/tpu-mlir)
 
-VAST is a library for program analysis and instrumentation of C/C++ and related languages.
-VAST provides a foundation for customizable program representation for a broad spectrum
-of analyses. Using the MLIR infrastructure, VAST provides a toolset to represent C/C++
-program at various stages of the compilation and to transform the representation to the
-best-fit program abstraction.
+TPU-MLIR imports models from common machine-learning formats and lowers them
+through high-level and TPU-specific dialects for SOPHGO processors. It includes
+optimization, quantization, code-generation, and deployment tooling.
 
-## [Verona](https://github.com/microsoft/verona)
+## [Triton](https://github.com/triton-lang/triton)
 
-Project Verona is a research programming language to explore the concept of
-concurrent ownership. They are providing a new concurrency model that seamlessly
-integrates ownership.
+Triton is a Python language and compiler for writing efficient custom deep
+learning primitives. Its MLIR-based compiler targets NVIDIA and AMD GPUs, with
+a CPU backend under development.
 
-## [Zaozi](https://github.com/sequencer/zaozi)
+## [VAST](https://github.com/trailofbits/vast)
 
-Zaozi is an project aimed at rewriting [Chisel](https://github.com/chipsalliance/chisel) in
-pure Scala 3 and MLIR. it provides a lean eDSL in Scala 3 and binds MLIR C-API with JVM 
-Project Panama.
-The goal of this project is providing an eDSL frontend framework for hardware designs.
+VAST is an experimental C and C++ program-analysis and instrumentation
+pipeline. It uses a hierarchy of MLIR dialects to retain source-level semantics
+while progressively lowering programs.
+
+## [Zaozi](https://github.com/xinpian-tech/zaozi)
+
+Zaozi is an experimental hardware embedded DSL written in Scala 3. It provides
+direct bindings to the MLIR and CIRCT C APIs and uses them to construct modular
+hardware compiler frontends.


### PR DESCRIPTION
Audit the existing entries against current public project documentation and rewrite their descriptions to state how each project uses MLIR.

Expand the directory from 44 to 55 entries by adding publicly documented projects including Buddy MLIR, ByteIR, CUDA-Q, EUDSL, Hexagon-MLIR, IMEX, MLIR-AIR, MLIR-TensorRT, MQT, Numba-MLIR, Qwerty, rocMLIR, ScaleHLS, and TPP-MLIR. Replace the generic Kokkos entry with LAPIS, the MLIR compiler that targets Kokkos.

Remove Nod Distributed Runtime, the proposed-only P4 integration, and Verona because their current public materials do not establish an applicable MLIR project. Retain historically relevant projects while clearly labeling Firefly, PlaidML, and MLIR-EmitC as archived, and point MLIR-EmitC readers to its upstream replacement.

Update moved repositories and stale descriptions for projects such as IREE, Mojo, MLIR-AIE, Pylir, Triton, and Zaozi. Add an explicit inclusion criterion, contribution guidance, and a last-modified date, then normalize naming and sort all entries alphabetically.

Verify exact case-insensitive ordering, unique and well-formed project headings and links, and a clean Git diff.

Assisted-by: Codex